### PR TITLE
More robust canAccessKeychain

### DIFF
--- a/Other/ValetDefines.h
+++ b/Other/ValetDefines.h
@@ -37,3 +37,6 @@
             } \
         } \
     } while(0)
+
+/// Compile flag for building against iOS 8.
+#define VAL_IOS_8_OR_LATER (TARGET_OS_IPHONE && __IPHONE_8_0)

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '1.1.2'
+  s.version  = '1.1.3'
   s.license  = 'Apache'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		EAEAA89F1B16818400F7AA98 /* VALValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC181AB7B83300EDB6E3 /* VALValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA8A11B16818400F7AA98 /* VALSynchronizableValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA8A21B16818E00F7AA98 /* VALValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC231AB7BA0C00EDB6E3 /* VALValet_Protected.h */; };
-		EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; };
+		EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA8A41B16821D00F7AA98 /* VALValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC191AB7B83300EDB6E3 /* VALValet.m */; };
 		EAEAA8A61B16821D00F7AA98 /* VALSynchronizableValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */; };
 		EAEAA8AC1B16864D00F7AA98 /* Valet.h in Headers */ = {isa = PBXBuildFile; fileRef = EA1E1F861A8C46080067C991 /* Valet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -23,7 +23,7 @@
 		EAEEAC1D1AB7B84000EDB6E3 /* VALSynchronizableValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */; };
 		EAEEAC201AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1F1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m */; };
 		EAEEAC271AB7BC5700EDB6E3 /* VALValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC231AB7BA0C00EDB6E3 /* VALValet_Protected.h */; };
-		EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; };
+		EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEEAC2A1AB7BD4800EDB6E3 /* VALValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC181AB7B83300EDB6E3 /* VALValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEEAC2B1AB7BD7400EDB6E3 /* VALSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1E1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEEAC2C1AB7BD7900EDB6E3 /* VALSynchronizableValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -32,7 +32,7 @@
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     return (&kSecAttrAccessControl != NULL && &kSecUseOperationPrompt != NULL);
 #else
     return NO;
@@ -85,7 +85,7 @@
 
 - (BOOL)containsObjectForKey:(NSString *)key;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     OSStatus status = [self containsObjectForKey:key options:@{ (__bridge id)kSecUseNoAuthenticationUI : @YES }];
     BOOL const keyAlreadyInKeychain = (status == errSecInteractionNotAllowed);
     return keyAlreadyInKeychain;
@@ -101,7 +101,7 @@
 
 - (NSError *)migrateObjectsMatchingQuery:(NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     if ([[self class] supportsSecureEnclaveKeychainItems]) {
         VALCheckCondition(secItemQuery[(__bridge id)kSecUseOperationPrompt] == nil, [NSError errorWithDomain:VALMigrationErrorDomain code:VALMigrationErrorInvalidQuery userInfo:nil], @"kSecUseOperationPrompt is not supported in a migration query. Keychain items can not be migrated en masse from the Secure Enclave.");
     }
@@ -114,7 +114,7 @@
 
 - (BOOL)setObject:(NSData *)value forKey:(NSString *)key userPrompt:(NSString *)userPrompt
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     return [self setObject:value forKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
 #else
     return NO;
@@ -123,7 +123,7 @@
 
 - (NSData *)objectForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     return [self objectForKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
 #else
     return nil;
@@ -132,7 +132,7 @@
 
 - (BOOL)setString:(NSString *)string forKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     return [self setString:string forKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
 #else
     return NO;
@@ -141,7 +141,7 @@
 
 - (NSString *)stringForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     return [self stringForKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
 #else
     return nil;
@@ -152,7 +152,7 @@
 
 - (NSMutableDictionary *)mutableBaseQueryWithIdentifier:(NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
 {
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     NSMutableDictionary *mutableBaseQuery = [super mutableBaseQueryWithIdentifier:identifier initializer:initializer accessibility:accessibility];
     
     // Add the access control, which opts us in to Secure Element storage.

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -32,7 +32,7 @@
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
-#if TARGET_OS_IPHONE && __IPHONE_8_0 && !TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IPHONE && __IPHONE_8_0
     return (&kSecAttrAccessControl != NULL && &kSecUseOperationPrompt != NULL);
 #else
     return NO;
@@ -69,6 +69,19 @@
 }
 
 #pragma mark - VALValet
+
+- (BOOL)canAccessKeychain;
+{
+    // To avoid prompting the user for Touch ID or passcode, create a VALValet with our identifier and accessibility and ask it if it can access the keychain.
+    VALValet *noPromptValet = nil;
+    if ([self isSharedAcrossApplications]) {
+        noPromptValet = [[VALValet alloc] initWithSharedAccessGroupIdentifier:self.identifier accessibility:self.accessibility];
+    } else {
+        noPromptValet = [[VALValet alloc] initWithIdentifier:self.identifier accessibility:self.accessibility];
+    }
+    
+    return [noPromptValet canAccessKeychain];
+}
 
 - (BOOL)containsObjectForKey:(NSString *)key;
 {

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -36,7 +36,7 @@ NSString *VALStringForAccessibility(VALAccessibility accessibility)
             return @"AccessibleAfterFirstUnlock";
         case VALAccessibilityAlways:
             return @"AccessibleAlways";
-#if __IPHONE_8_0 || __MAC_10_10
+#if VAL_IOS_8_OR_LATER || __MAC_10_10
         case VALAccessibilityWhenPasscodeSetThisDeviceOnly:
             return @"AccessibleWhenPasscodeSetThisDeviceOnly";
 #endif
@@ -607,7 +607,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
             return (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
         case VALAccessibilityAlways:
             return (__bridge id)kSecAttrAccessibleAlways;
-#if __IPHONE_8_0 || __MAC_10_10
+#if VAL_IOS_8_OR_LATER || __MAC_10_10
         case VALAccessibilityWhenPasscodeSetThisDeviceOnly:
             return (__bridge id)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
 #endif

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -247,7 +247,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
         // Manually add the key to the keychain since we don't care about duplicates and are optimizing for speed.
         NSMutableDictionary *query = [self.baseQuery mutableCopy];
         [query addEntriesFromDictionary:[self _secItemFormatDictionaryWithKey:canaryKey]];
-        [query addEntriesFromDictionary:@{ (__bridge id)kSecValueData : [canaryValue dataUsingEncoding:NSUTF8StringEncoding] }];
+        query[(__bridge id)kSecValueData] = [canaryValue dataUsingEncoding:NSUTF8StringEncoding];
         (void)VALAtomicSecItemAdd((__bridge CFDictionaryRef)query, NULL);
         
         NSString *const retrievedCanaryValue = [self stringForKey:canaryKey];
@@ -435,7 +435,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
         } else {
             // No previous item found, add the new one.
             NSMutableDictionary *keychainData = [query mutableCopy];
-            [keychainData addEntriesFromDictionary:@{ (__bridge id)kSecValueData : value }];
+            keychainData[(__bridge id)kSecValueData] = value;
             
             status = VALAtomicSecItemAdd((__bridge CFDictionaryRef)keychainData, NULL);
         }

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -21,6 +21,7 @@
 #import <XCTest/XCTest.h>
 
 #import <Valet/Valet.h>
+#import <Valet/ValetDefines.h>
 
 
 // The iPhone simulator fakes entitlements, allowing us to test the iCloud Keychain (VALSynchronizableValet) code without writing a signed host app.
@@ -48,7 +49,7 @@
 @property (nonatomic, readwrite) VALValet *valet;
 @property (nonatomic, readwrite) VALTestingValet *testingValet;
 @property (nonatomic, readwrite) VALSynchronizableValet *synchronizableValet;
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
 @property (nonatomic, readwrite) VALSecureEnclaveValet *secureEnclaveValet;
 #endif
 @property (nonatomic, copy, readwrite) NSString *key;
@@ -71,7 +72,7 @@
     self.valet = [[VALValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
     self.testingValet = [[VALTestingValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
     self.synchronizableValet = [[VALSynchronizableValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
 #endif
     
@@ -79,7 +80,7 @@
     [self.valet removeAllObjects];
     [self.testingValet removeAllObjects];
     [self.synchronizableValet removeAllObjects];
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     [self.secureEnclaveValet removeAllObjects];
 #endif
     
@@ -122,7 +123,7 @@
     XCTAssertNil([[VALValet alloc] initWithIdentifier:@"test" accessibility:0]);
     XCTAssertNil([[VALSynchronizableValet alloc] initWithIdentifier:@"test" accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly]);
 
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     XCTAssertNil([[VALSecureEnclaveValet alloc] initWithIdentifier:@"test" accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly]);
 #endif
 }
@@ -132,7 +133,7 @@
     // Testing environments should always be able to access the keychain.
     XCTAssertTrue([self.valet canAccessKeychain]);
     
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {
         XCTAssertTrue([self.secureEnclaveValet canAccessKeychain]);
     }
@@ -437,7 +438,7 @@
     XCTAssertEqual([self.valet migrateObjectsMatchingQuery:@{ (__bridge id)kSecReturnRef : (__bridge id)kCFBooleanTrue } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     XCTAssertEqual([self.valet migrateObjectsMatchingQuery:@{ (__bridge id)kSecReturnPersistentRef : (__bridge id)kCFBooleanFalse } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
     if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {
         XCTAssertEqual([self.secureEnclaveValet migrateObjectsMatchingQuery:@{ (__bridge id)kSecUseOperationPrompt : @"Migration Prompt" } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     }
@@ -522,7 +523,7 @@
     }
 }
 
-#if TARGET_OS_IPHONE && __IPHONE_8_0
+#if VAL_IOS_8_OR_LATER
 - (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenMigratingToSecureEnclave;
 {
     if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -48,6 +48,9 @@
 @property (nonatomic, readwrite) VALValet *valet;
 @property (nonatomic, readwrite) VALTestingValet *testingValet;
 @property (nonatomic, readwrite) VALSynchronizableValet *synchronizableValet;
+#if TARGET_OS_IPHONE && __IPHONE_8_0
+@property (nonatomic, readwrite) VALSecureEnclaveValet *secureEnclaveValet;
+#endif
 @property (nonatomic, copy, readwrite) NSString *key;
 @property (nonatomic, copy, readwrite) NSString *string;
 @property (nonatomic, copy, readwrite) NSString *secondaryString;
@@ -64,14 +67,21 @@
 {
     [super setUp];
     
-    self.valet = [[VALValet alloc] initWithIdentifier:@"valet_testing" accessibility:VALAccessibilityWhenUnlocked];
-    self.testingValet = [[VALTestingValet alloc] initWithIdentifier:@"valet_testing" accessibility:VALAccessibilityWhenUnlocked];
-    self.synchronizableValet = [[VALSynchronizableValet alloc] initWithIdentifier:@"valet_testing" accessibility:VALAccessibilityWhenUnlocked];
+    NSString *const valetTestingIdentifier = @"valet_testing";
+    self.valet = [[VALValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
+    self.testingValet = [[VALTestingValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
+    self.synchronizableValet = [[VALSynchronizableValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenUnlocked];
+#if TARGET_OS_IPHONE && __IPHONE_8_0
+    self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:valetTestingIdentifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
+#endif
     
     // In case testing quit unexpectedly, clean up the keychain from last time.
     [self.valet removeAllObjects];
     [self.testingValet removeAllObjects];
     [self.synchronizableValet removeAllObjects];
+#if TARGET_OS_IPHONE && __IPHONE_8_0
+    [self.secureEnclaveValet removeAllObjects];
+#endif
     
     for (VALValet *additionalValet in self.additionalValets) {
         [additionalValet removeAllObjects];
@@ -121,6 +131,12 @@
 {
     // Testing environments should always be able to access the keychain.
     XCTAssertTrue([self.valet canAccessKeychain]);
+    
+#if TARGET_OS_IPHONE && __IPHONE_8_0
+    if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {
+        XCTAssertTrue([self.secureEnclaveValet canAccessKeychain]);
+    }
+#endif
 }
 
 - (void)test_stringForKey_retrievesString;
@@ -421,10 +437,9 @@
     XCTAssertEqual([self.valet migrateObjectsMatchingQuery:@{ (__bridge id)kSecReturnRef : (__bridge id)kCFBooleanTrue } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     XCTAssertEqual([self.valet migrateObjectsMatchingQuery:@{ (__bridge id)kSecReturnPersistentRef : (__bridge id)kCFBooleanFalse } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     
-    // Only test VALSecureEnclaveValet on iOS
 #if TARGET_OS_IPHONE && __IPHONE_8_0
     if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {
-        XCTAssertEqual([self.valet migrateObjectsMatchingQuery:@{ (__bridge id)kSecUseOperationPrompt : @"Migration Prompt" } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
+        XCTAssertEqual([self.secureEnclaveValet migrateObjectsMatchingQuery:@{ (__bridge id)kSecUseOperationPrompt : @"Migration Prompt" } removeOnCompletion:NO].code, VALMigrationErrorInvalidQuery);
     }
 #endif
 }
@@ -506,6 +521,32 @@
         XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
     }
 }
+
+#if TARGET_OS_IPHONE && __IPHONE_8_0
+- (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenMigratingToSecureEnclave;
+{
+    if ([VALSecureEnclaveValet supportsSecureEnclaveKeychainItems]) {
+        VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
+        [self.additionalValets addObject:otherValet];
+        
+        NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+        
+        for (NSString *key in keyStringPairToMigrateMap) {
+            XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+        }
+        
+        for (NSString *key in keyStringPairToMigrateMap) {
+            XCTAssertFalse([self.secureEnclaveValet containsObjectForKey:key]);
+        }
+        
+        XCTAssertNil([self.secureEnclaveValet migrateObjectsFromValet:otherValet removeOnCompletion:NO]);
+        
+        for (NSString *key in keyStringPairToMigrateMap) {
+            XCTAssertTrue([self.secureEnclaveValet containsObjectForKey:key]);
+        }
+    }
+}
+#endif
 
 - (void)test_isEqual_equivalentValetsCanAccessSameData;
 {


### PR DESCRIPTION
Looks like you can write to the keychain on OS X even when you don't have read access (or at least find out that you're trying to add a duplicate item when you don't have access). So instead of cleverly trying to discern the error message behind a SecItemAdd, add the item to the keychain and then see if we can read it back out.

Also did some cleanup to allow VALSecureEnclaveValet to be unit tested.