### PR TITLE
Vulnerability test should not rely on Finder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 script:
     - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 build test
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.10 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '1.2'
+  s.version  = '1.2.1'
   s.license  = 'Apache'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -307,7 +307,7 @@
     SecTrustedApplicationRef trustedAppSelf = NULL;
     SecTrustedApplicationRef trustedAppFinder = NULL;
     XCTAssertEqual(SecTrustedApplicationCreateFromPath(NULL, &trustedAppSelf), errSecSuccess);
-    XCTAssertEqual(SecTrustedApplicationCreateFromPath("/Applications/Finder.app", &trustedAppFinder), errSecSuccess);
+    XCTAssertEqual(SecTrustedApplicationCreateFromPath("/System/Library/CoreServices/SystemUIServer.app", &trustedAppFinder), errSecSuccess);
     XCTAssertEqual(SecAccessCreate((__bridge CFStringRef)@"Access Control List",
                                    (__bridge CFArrayRef)@[ (__bridge id)trustedAppSelf, (__bridge id)trustedAppFinder ],
                                    &accessList),
@@ -321,7 +321,7 @@
     // The potentially vulnerable keychain item should exist in our Valet now.
     XCTAssertTrue([valet containsObjectForKey:vulnKey]);
     
-    // Get a persistent reference to the vulnerable keychain entry.
+    // Get a reference to the vulnerable keychain entry.
     query[(__bridge id)kSecReturnRef] = @YES;
     query[(__bridge id)kSecReturnAttributes] = @YES;
     CFTypeRef referenceOutTypeRef = NULL;
@@ -343,7 +343,7 @@
     CFRelease(trustedAppSelf);
     CFRelease(trustedAppFinder);
     
-    // If you manually inspect the keychain via Keychain.app and search for MacOSVulnTest, you'll see that the Access Control for the only item matching this query has only xctest in the Access Control list. You'll see that this is not the case if you remove the line `[valet setString:vulnKeyOtherValue forKey:vulnKey];`.
+    // If you add a breakpoint here and manually inspect the keychain via Keychain.app and search for MacOSVulnTest, you'll see that the Access Control for the only item matching this query has only xctest in the Access Control list. You'll see that this is not the case if you break above the line `[valet setString:vulnKeyOtherValue forKey:vulnKey];`.
 }
 #endif
 


### PR DESCRIPTION
SystemUIServer has lived in a stable location for many OS releases, and it is impossible to run your Mac without it.

cc @EricMuller22 @martinmroz @kyleve 