### PR TITLE
Use Xcode 6.3 beta on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: beta-xcode6.3
 script:
     - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.10 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 osx_image: beta-xcode6.3
 script:
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 build test
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.10 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test


### PR DESCRIPTION
Trying out Xcode 6.3 CI. Should allow us to use `nonnull` and `nullable` syntax instead of `__attribute` syntax.

cc @EricMuller22 @mtauraso @rhgills 