### PR TITLE
Valet to 2.0

### DIFF
--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '1.3.1'
+  s.version  = '2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -621,6 +622,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -640,6 +642,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = Valet;
 				SDKROOT = macosx;
@@ -656,6 +659,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = Valet;
 				SDKROOT = macosx;
@@ -676,6 +680,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -695,6 +700,7 @@
 					"$(inherited)",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -714,6 +720,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTouchIDTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -729,6 +736,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTouchIDTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 		EA1E1F7B1A8C46080067C991 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Square, Inc.";
 				TargetAttributes = {
 					EA1E1F821A8C46080067C991 = {
@@ -517,6 +517,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -611,6 +612,7 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -625,6 +627,7 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -684,6 +687,7 @@
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -704,6 +708,7 @@
 				INFOPLIST_FILE = ValetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -724,6 +729,7 @@
 				INFOPLIST_FILE = ValetTouchIDTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -740,6 +746,7 @@
 				INFOPLIST_FILE = ValetTouchIDTest/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Valet.xcodeproj/xcshareddata/xcschemes/Valet Mac.xcscheme
+++ b/Valet.xcodeproj/xcshareddata/xcschemes/Valet Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Valet.xcodeproj/xcshareddata/xcschemes/Valet iOS.xcscheme
+++ b/Valet.xcodeproj/xcshareddata/xcschemes/Valet iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Valet.xcodeproj/xcshareddata/xcschemes/ValetTouchIDTest.xcscheme
+++ b/Valet.xcodeproj/xcshareddata/xcschemes/ValetTouchIDTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,15 +38,18 @@
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Valet/VALSecureEnclaveValet.h
+++ b/Valet/VALSecureEnclaveValet.h
@@ -21,9 +21,6 @@
 #import "VALValet.h"
 
 
-NS_ASSUME_NONNULL_BEGIN
-
-
 /// Reads and writes keychain elements that are stored on the Secure Enclave (supported on iOS 8.0 or later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. Accessing or modifying these items will require the user to confirm their presence via Touch ID or passcode entry. If no passcode is set on the device, the below methods will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device. Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
 NS_CLASS_AVAILABLE_IOS(8_0)
 @interface VALSecureEnclaveValet : VALValet
@@ -32,27 +29,24 @@ NS_CLASS_AVAILABLE_IOS(8_0)
 + (BOOL)supportsSecureEnclaveKeychainItems;
 
 /// Creates a Valet that reads/writes Secure Enclave keychain elements.
-- (nullable instancetype)initWithIdentifier:(NSString *)identifier;
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier;
 
 /// Creates a Valet that reads/writes Secure Enclave keychain elements that can be shared across applications written by the same development team.
 /// @param sharedAccessGroupIdentifier This must correspond with the value for keychain-access-groups in your Entitlements file.
-- (nullable instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier;
 
 /// Convenience method for retrieving data from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
-- (nullable NSData *)objectForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 
 /// Convenience method for retrieving a string from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
-- (nullable NSString *)stringForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 
 /// This method is not supported on VALSecureEnclaveValet.
-- (NSSet *)allKeys __attribute__((unavailable("VALSecureEnclaveValet does not support -allKeys")));
+- (nonnull NSSet *)allKeys NS_UNAVAILABLE;
 
 /// This method is not supported on VALSecureEnclaveValet.
-- (BOOL)removeAllObjects __attribute__((unavailable("VALSecureEnclaveValet does not support -removeAllObjects")));
+- (BOOL)removeAllObjects NS_UNAVAILABLE;
 
 @end
-
-
-NS_ASSUME_NONNULL_END

--- a/Valet/VALSecureEnclaveValet.h
+++ b/Valet/VALSecureEnclaveValet.h
@@ -38,16 +38,10 @@ NS_CLASS_AVAILABLE_IOS(8_0)
 /// @param sharedAccessGroupIdentifier This must correspond with the value for keychain-access-groups in your Entitlements file.
 - (nullable instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier;
 
-/// Convenience method for inserting data into the keychain with a user prompt.
-/// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI when updating a value.
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 /// Convenience method for retrieving data from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
 - (nullable NSData *)objectForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 
-/// Convenience method for inserting a string into the keychain with a user prompt.
-/// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI when updating a value.
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key userPrompt:(NSString *)userPrompt;
 /// Convenience method for retrieving a string from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
 - (nullable NSString *)stringForKey:(NSString *)key userPrompt:(NSString *)userPrompt;

--- a/Valet/VALSecureEnclaveValet.h
+++ b/Valet/VALSecureEnclaveValet.h
@@ -37,10 +37,12 @@ NS_CLASS_AVAILABLE_IOS(8_0)
 
 /// Convenience method for retrieving data from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
+/// @return The object currently stored in the keychain for the provided key. Returns nil if no string exists in the keychain for the specified key, or if the keychain is inaccessible.
 - (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 
 /// Convenience method for retrieving a string from the keychain with a user prompt.
 /// @param userPrompt The prompt displayed to the user in Apple's Touch ID and passcode entry UI.
+/// @return The string currently stored in the keychain for the provided key. Returns nil if no string exists in the keychain for the specified key, or if the keychain is inaccessible.
 - (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 
 /// This method is not supported on VALSecureEnclaveValet.

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -117,16 +117,7 @@
 
 #pragma mark - Public Methods
 
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key userPrompt:(NSString *)userPrompt
-{
-#if VAL_IOS_8_OR_LATER
-    return [self setObject:value forKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
-#else
-    return NO;
-#endif
-}
-
-- (NSData *)objectForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 {
 #if VAL_IOS_8_OR_LATER
     return [self objectForKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
@@ -135,16 +126,7 @@
 #endif
 }
 
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key userPrompt:(NSString *)userPrompt;
-{
-#if VAL_IOS_8_OR_LATER
-    return [self setString:string forKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];
-#else
-    return NO;
-#endif
-}
-
-- (NSString *)stringForKey:(NSString *)key userPrompt:(NSString *)userPrompt;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nonnull NSString *)userPrompt;
 {
 #if VAL_IOS_8_OR_LATER
     return [self stringForKey:key options:@{ (__bridge id)kSecUseOperationPrompt : userPrompt }];

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -143,7 +143,7 @@
     NSMutableDictionary *mutableBaseQuery = [super mutableBaseQueryWithIdentifier:identifier initializer:initializer accessibility:accessibility];
     
     // Add the access control, which opts us in to Secure Element storage.
-    mutableBaseQuery[(__bridge id)kSecAttrAccessControl] = (__bridge id)SecAccessControlCreateWithFlags(NULL, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, kSecAccessControlUserPresence, NULL);
+    mutableBaseQuery[(__bridge id)kSecAttrAccessControl] = (__bridge_transfer id)SecAccessControlCreateWithFlags(NULL, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, kSecAccessControlUserPresence, NULL);
     
     // kSecAttrAccessControl and kSecAttrAccessible are mutually exclusive, so remove kSecAttrAccessible from our query.
     [mutableBaseQuery removeObjectForKey:(__bridge id)kSecAttrAccessible];

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -42,12 +42,12 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithIdentifier:(NSString *)identifier;
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier;
 {
     return [self initWithIdentifier:identifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
 }
 
-- (instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(accessibility == VALAccessibilityWhenPasscodeSetThisDeviceOnly, nil, @"Accessibility on SecureEnclaveValet must be VALAccessibilityWhenPasscodeSetThisDeviceOnly");
     VALCheckCondition([[self class] supportsSecureEnclaveKeychainItems], nil, @"This device does not support storing data on the secure enclave.");
@@ -55,12 +55,12 @@
     return [super initWithIdentifier:identifier accessibility:accessibility];
 }
 
-- (instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier;
 {
     return [self initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
 }
 
-- (instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(accessibility == VALAccessibilityWhenPasscodeSetThisDeviceOnly, nil, @"Accessibility on SecureEnclaveValet must be VALAccessibilityWhenPasscodeSetThisDeviceOnly");
     VALCheckCondition([[self class] supportsSecureEnclaveKeychainItems], nil, @"This device does not support storing data on the secure enclave.");
@@ -83,7 +83,7 @@
     return [noPromptValet canAccessKeychain];
 }
 
-- (BOOL)containsObjectForKey:(NSString *)key;
+- (BOOL)containsObjectForKey:(nonnull NSString *)key;
 {
 #if VAL_IOS_8_OR_LATER
     OSStatus status = [self containsObjectForKey:key options:@{ (__bridge id)kSecUseNoAuthenticationUI : @YES }];
@@ -94,9 +94,9 @@
 #endif
 }
 
-- (NSSet *)allKeys;
+- (nonnull NSSet *)allKeys;
 {
-    VALCheckCondition(NO, nil, @"%s is not supported on %@", __PRETTY_FUNCTION__, NSStringFromClass([self class]));
+    VALCheckCondition(NO, [NSSet new], @"%s is not supported on %@", __PRETTY_FUNCTION__, NSStringFromClass([self class]));
 }
 
 - (BOOL)removeAllObjects;
@@ -104,7 +104,7 @@
     VALCheckCondition(NO, NO, @"%s is not supported on %@", __PRETTY_FUNCTION__, NSStringFromClass([self class]));
 }
 
-- (NSError *)migrateObjectsMatchingQuery:(NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
+- (nullable NSError *)migrateObjectsMatchingQuery:(nonnull NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
 {
 #if VAL_IOS_8_OR_LATER
     if ([[self class] supportsSecureEnclaveKeychainItems]) {
@@ -137,7 +137,7 @@
 
 #pragma mark - Protected Methods
 
-- (NSMutableDictionary *)mutableBaseQueryWithIdentifier:(NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
+- (nonnull NSMutableDictionary *)mutableBaseQueryWithIdentifier:(nonnull NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
 {
 #if VAL_IOS_8_OR_LATER
     NSMutableDictionary *mutableBaseQuery = [super mutableBaseQueryWithIdentifier:identifier initializer:initializer accessibility:accessibility];
@@ -150,11 +150,11 @@
     
     return mutableBaseQuery;
 #else
-    return nil;
+    return [NSMutableDictionary new];
 #endif
 }
 
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key options:(NSDictionary *)options;
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key options:(NSDictionary *)options;
 {
     // Remove the key before trying to set it. This will prevent us from calling SecItemUpdate on an item stored on the Secure Enclave, which would cause iOS to prompt the user for authentication.
     [self removeObjectForKey:key];

--- a/Valet/VALSynchronizableValet.m
+++ b/Valet/VALSynchronizableValet.m
@@ -47,7 +47,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(accessibility == VALAccessibilityWhenUnlocked || accessibility == VALAccessibilityAfterFirstUnlock || accessibility == VALAccessibilityAlways, nil, @"Accessibility must not be scoped to this device");
     VALCheckCondition([[self class] supportsSynchronizableKeychainItems], nil, @"This device does not support synchronizing data to iCloud.");
@@ -55,7 +55,7 @@
     return [super initWithIdentifier:identifier accessibility:accessibility];
 }
 
-- (instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(accessibility == VALAccessibilityWhenUnlocked || accessibility == VALAccessibilityAfterFirstUnlock || accessibility == VALAccessibilityAlways, nil, @"Accessibility must not be scoped to this device");
     VALCheckCondition([[self class] supportsSynchronizableKeychainItems], nil, @"This device does not support synchronizing data to iCloud.");
@@ -65,7 +65,7 @@
 
 #pragma mark - Protected Methods
 
-- (NSMutableDictionary *)mutableBaseQueryWithIdentifier:(NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
+- (nonnull NSMutableDictionary *)mutableBaseQueryWithIdentifier:(nonnull NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
 {
     NSMutableDictionary *mutableBaseQuery = [super mutableBaseQueryWithIdentifier:identifier initializer:initializer accessibility:accessibility];
     

--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -21,9 +21,6 @@
 #import <Foundation/Foundation.h>
 
 
-NS_ASSUME_NONNULL_BEGIN
-
-
 typedef NS_ENUM(NSUInteger, VALAccessibility) {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accesible while the application is in the foreground. Valet data with this accessibility will migrate to a new device when using encrypted backups.
     VALAccessibilityWhenUnlocked = 1,
@@ -42,7 +39,7 @@ typedef NS_ENUM(NSUInteger, VALAccessibility) {
     VALAccessibilityAlwaysThisDeviceOnly,
 };
 
-extern NSString *const VALMigrationErrorDomain;
+extern NSString * __nonnull const VALMigrationErrorDomain;
 
 typedef NS_ENUM(NSUInteger, VALMigrationError) {
     /// Migration failed because the keychain query was not valid.
@@ -71,19 +68,19 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 
 /// Creates a Valet that reads/writes keychain elements with the desired accessibility.
 /// @see VALAccessibility
-- (nullable instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility __attribute((objc_designated_initializer));
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility NS_DESIGNATED_INITIALIZER;
 
 /// Creates a Valet that reads/writes keychain elements that can be shared across applications written by the same development team.
 /// @param sharedAccessGroupIdentifier This must correspond with the value for keychain-access-groups in your Entitlements file.
 /// @see VALAccessibility
-- (nullable instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility __attribute((objc_designated_initializer));
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility NS_DESIGNATED_INITIALIZER;
 
-@property (copy, readonly) NSString *identifier;
+@property (nonnull, copy, readonly) NSString *identifier;
 @property (readonly, getter=isSharedAcrossApplications) BOOL sharedAcrossApplications;
 @property (readonly) VALAccessibility accessibility;
 
 /// @return YES if otherValet reads from and writes to the same sandbox within the keychain as the receiver.
-- (BOOL)isEqualToValet:(VALValet *)otherValet;
+- (BOOL)isEqualToValet:(nonnull VALValet *)otherValet;
 
 /// @return YES if the keychain is accessible for reading and writing, NO otherwise.
 /// @note Determined by writing a value to the keychain and then reading it back out.
@@ -91,25 +88,25 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 
 /// @param value An NSData value to be inserted into the keychain.
 /// @return NO if the keychain is not accessible.
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key;
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key;
 /// @return The data currently stored in the keychain for the provided key.
-- (nullable NSData *)objectForKey:(NSString *)key;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key;
 
 /// @param string An NSString value to store in the keychain for the provided key.
 /// @return NO if the keychain is not accessible.
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key;
+- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key;
 /// @return The string currently stored in the keychain for the provided key.
-- (nullable NSString *)stringForKey:(NSString *)key;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key;
 
 /// @param key The key to look up in the keychain.
 /// @return YES if a value has been set for the given key, NO otherwise.
-- (BOOL)containsObjectForKey:(NSString *)key;
+- (BOOL)containsObjectForKey:(nonnull NSString *)key;
 /// @return The set of all (NSString) keys currently stored in this Valet instance.
-- (NSSet *)allKeys;
+- (nonnull NSSet *)allKeys;
 
 /// Removes a key/object pair from the keychain.
 /// @return NO if the keychain is not accessible.
-- (BOOL)removeObjectForKey:(NSString *)key;
+- (BOOL)removeObjectForKey:(nonnull NSString *)key;
 /// Removes all key/object pairs accessible by this Valet instance from the keychain.
 /// @return NO if the keychain is not accessible.
 - (BOOL)removeAllObjects;
@@ -118,13 +115,10 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 /// @return An error if the operation failed. Error domain will be <code>VALMigrationErrorDomain</code>, and codes will be of type <code>VALMigrationError</code>
 /// @see VALMigrationError
 /// @note The keychain is not modified if a failure occurs.
-- (nullable NSError *)migrateObjectsMatchingQuery:(NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
+- (nullable NSError *)migrateObjectsMatchingQuery:(nonnull NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
 /// Migrates objects from the passed-in Valet into the receiving Valet instance.
 /// @return An error if the operation failed. Error domain will be <code>VALMigrationErrorDomain</code>, and codes will be of type <code>VALMigrationError</code>
 /// @see VALMigrationError
-- (nullable NSError *)migrateObjectsFromValet:(VALValet *)valet removeOnCompletion:(BOOL)remove;
+- (nullable NSError *)migrateObjectsFromValet:(nonnull VALValet *)valet removeOnCompletion:(BOOL)remove;
 
 @end
-
-
-NS_ASSUME_NONNULL_END

--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -89,13 +89,13 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 /// @param value An NSData value to be inserted into the keychain.
 /// @return NO if the keychain is not accessible.
 - (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key;
-/// @return The data currently stored in the keychain for the provided key.
+/// @return The data currently stored in the keychain for the provided key. Returns nil if no object exists in the keychain for the specified key, or if the keychain is inaccessible.
 - (nullable NSData *)objectForKey:(nonnull NSString *)key;
 
 /// @param string An NSString value to store in the keychain for the provided key.
 /// @return NO if the keychain is not accessible.
 - (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key;
-/// @return The string currently stored in the keychain for the provided key.
+/// @return The string currently stored in the keychain for the provided key. Returns nil if no string exists in the keychain for the specified key, or if the keychain is inaccessible.
 - (nullable NSString *)stringForKey:(nonnull NSString *)key;
 
 /// @param key The key to look up in the keychain.

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -172,7 +172,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     VALCheckCondition(NO, nil, @"Use a designated initializer");
 }
 
-- (nullable instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(identifier.length > 0, nil, @"Valet requires an identifier");
     VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
@@ -189,7 +189,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return [[self class] _sharedValetForValet:self];
 }
 
-- (instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(sharedAccessGroupIdentifier.length > 0, nil, @"Valet requires a sharedAccessGroupIdentifier");
     VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
@@ -229,7 +229,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 #pragma mark - NSCopying
 
-- (instancetype)copyWithZone:(NSZone *)zone;
+- (nonnull instancetype)copyWithZone:(nullable NSZone *)zone;
 {
     // We're immutable, so just return self.
     return self;
@@ -237,7 +237,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 #pragma mark - Public Methods
 
-- (BOOL)isEqualToValet:(VALValet *)otherValet;
+- (BOOL)isEqualToValet:(nonnull VALValet *)otherValet;
 {
     return [self.baseQuery isEqualToDictionary:otherValet.baseQuery];
 }
@@ -262,34 +262,34 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return canAccessKeychain;
 }
 
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key;
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key;
 {
     return [self setObject:value forKey:key options:nil];
 }
 
-- (NSData *)objectForKey:(NSString *)key;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key;
 {
     return [self objectForKey:key options:nil];
 }
 
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key;
+- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key;
 {
     return [self setString:string forKey:key options:nil];
 }
 
-- (NSString *)stringForKey:(NSString *)key;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key;
 {
     return [self stringForKey:key options:nil];
 }
 
-- (BOOL)containsObjectForKey:(NSString *)key;
+- (BOOL)containsObjectForKey:(nonnull NSString *)key;
 {
     OSStatus status = [self containsObjectForKey:key options:nil];
     BOOL const keyAlreadyInKeychain = (status == errSecSuccess);
     return keyAlreadyInKeychain;
 }
 
-- (NSSet *)allKeys;
+- (nonnull NSSet *)allKeys;
 {
     return [self allKeysWithOptions:nil];
 }
@@ -308,7 +308,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 #pragma mark - Public Methods - Migration
 
-- (NSError *)migrateObjectsMatchingQuery:(NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
+- (nullable NSError *)migrateObjectsMatchingQuery:(nonnull NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
 {
     VALCheckCondition(secItemQuery.allKeys.count > 0, [NSError errorWithDomain:VALMigrationErrorDomain code:VALMigrationErrorInvalidQuery userInfo:nil], @"Migration requires secItemQuery to contain values.");
     VALCheckCondition(secItemQuery[(__bridge id)kSecMatchLimit] != (__bridge id)kSecMatchLimitOne, [NSError errorWithDomain:VALMigrationErrorDomain code:VALMigrationErrorInvalidQuery userInfo:nil], @"Migration requires kSecMatchLimit to be set to kSecMatchLimitAll.");
@@ -405,15 +405,17 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return nil;
 }
 
-- (NSError *)migrateObjectsFromValet:(VALValet *)valet removeOnCompletion:(BOOL)remove;
+- (nullable NSError *)migrateObjectsFromValet:(VALValet *)valet removeOnCompletion:(BOOL)remove;
 {
     return [self migrateObjectsMatchingQuery:valet.baseQuery removeOnCompletion:remove];
 }
 
 #pragma mark - Protected Methods
 
-- (NSMutableDictionary *)mutableBaseQueryWithIdentifier:(NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
+- (nonnull NSMutableDictionary *)mutableBaseQueryWithIdentifier:(nonnull NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
 {
+    VALCheckCondition(identifier.length > 0, nil, @"Must provide a valid identifier");
+    
     return [@{
               // Valet only handles generic passwords.
               (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
@@ -424,7 +426,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
               } mutableCopy];
 }
 
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key options:(NSDictionary *)options;
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     VALCheckCondition(key.length > 0, NO, @"Can not set a value with an empty key.");
     VALCheckCondition(value.length > 0, NO, @"Can not set an empty value.");
@@ -466,7 +468,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return (status == errSecSuccess);
 }
 
-- (NSData *)objectForKey:(NSString *)key options:(NSDictionary *)options;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     VALCheckCondition(key.length > 0, nil, @"Can not retrieve value with empty key.");
     NSMutableDictionary *query = [self.baseQuery mutableCopy];
@@ -484,7 +486,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return (status == errSecSuccess) ? value : nil;
 }
 
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key options:(NSDictionary *)options;
+- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     VALCheckCondition(string.length > 0, NO, @"Can not set empty string for key.");
     NSData *stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
@@ -495,7 +497,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return NO;
 }
 
-- (NSString *)stringForKey:(NSString *)key options:(NSDictionary *)options;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     NSData *stringData = [self objectForKey:key options:options];
     if (stringData.length > 0) {
@@ -505,7 +507,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return nil;
 }
 
-- (OSStatus)containsObjectForKey:(NSString *)key options:(NSDictionary *)options;
+- (OSStatus)containsObjectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     VALCheckCondition(key.length > 0, errSecParam, @"Can not check if empty key exists in the keychain.");
     
@@ -519,7 +521,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return status;
 }
 
-- (NSSet *)allKeysWithOptions:(NSDictionary *)options;
+- (nonnull NSSet *)allKeysWithOptions:(nullable NSDictionary *)options;
 {
     NSSet *keys = [NSSet set];
     NSMutableDictionary *query = [self.baseQuery mutableCopy];
@@ -554,7 +556,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return keys;
 }
 
-- (BOOL)removeObjectForKey:(NSString *)key options:(NSDictionary *)options;
+- (BOOL)removeObjectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 {
     VALCheckCondition(key.length > 0, NO, @"Can not remove object for empty key from the keychain.");
     
@@ -573,7 +575,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return (status != errSecInteractionNotAllowed);
 }
 
-- (BOOL)removeAllObjectsWithOptions:(NSDictionary *)options;
+- (BOOL)removeAllObjectsWithOptions:(nullable NSDictionary *)options;
 {
     for (NSString *key in [self allKeys]) {
         if (![self removeObjectForKey:key options:options]) {
@@ -586,7 +588,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 #pragma mark - Properties
 
-- (NSString *)secServiceIdentifier;
+- (nonnull NSString *)secServiceIdentifier;
 {
     return self.baseQuery[(__bridge id)kSecAttrService];
 }
@@ -594,7 +596,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 #pragma mark - Private Methods
 
 /// Programatically grab the required prefix for the shared access group (i.e. Bundle Seed ID). The value for the kSecAttrAccessGroup key in queries for data that is shared between apps must be of the format bundleSeedID.sharedAccessGroup. For more information on the Bundle Seed ID, see https://developer.apple.com/library/ios/qa/qa1713/_index.html
-- (NSString *)_sharedAccessGroupPrefix;
+- (nullable NSString *)_sharedAccessGroupPrefix;
 {
     NSDictionary *query = @{ (__bridge NSString *)kSecClass : (__bridge NSString *)kSecClassGenericPassword,
                              (__bridge id)kSecAttrAccount : @"SharedAccessGroupPrefixPlaceholder",
@@ -642,7 +644,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     }
 }
 
-- (NSDictionary *)_secItemFormatDictionaryWithKey:(NSString *)key;
+- (nonnull NSDictionary *)_secItemFormatDictionaryWithKey:(nonnull NSString *)key;
 {
     VALCheckCondition(key.length > 0, @{}, @"Must provide a valid key");
     return @{ (__bridge id)kSecAttrAccount : key };

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -167,7 +167,12 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 #pragma mark - Initialization
 
-- (instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility;
+- (nullable instancetype)init NS_UNAVAILABLE;
+{
+    VALCheckCondition(NO, nil, @"Use a designated initializer");
+}
+
+- (nullable instancetype)initWithIdentifier:(NSString *)identifier accessibility:(VALAccessibility)accessibility;
 {
     VALCheckCondition(identifier.length > 0, nil, @"Valet requires an identifier");
     VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");

--- a/ValetTests/Info.plist
+++ b/ValetTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.squareup.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ValetTouchIDTest/Info.plist
+++ b/ValetTouchIDTest/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.squareup.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ValetTouchIDTest/ValetSecureElementTestViewController.m
+++ b/ValetTouchIDTest/ValetSecureElementTestViewController.m
@@ -48,7 +48,7 @@
 
 - (IBAction)setOrUpdateItem:(id)sender;
 {
-    BOOL setOrUpdatedItem = [self.secureEnclaveValet setString:[NSString stringWithFormat:@"I am here! %@", [[NSUUID new] UUIDString]] forKey:self.username userPrompt:@"Use TouchID to update this password"];
+    BOOL setOrUpdatedItem = [self.secureEnclaveValet setString:[NSString stringWithFormat:@"I am here! %@", [[NSUUID new] UUIDString]] forKey:self.username];
     
     self.textView.text = [self.textView.text stringByAppendingFormat:@"\n%s %@", __PRETTY_FUNCTION__, (setOrUpdatedItem ? @"Success" : @"Failure")];
 }


### PR DESCRIPTION
• Support Xcode 7
• Treat warnings as errors in all targets
• Breaking change: Remove `set*:forKey:prompt:` on VALSecureEnclaveValet since `prompt` will never be used.
• Do not use `NS_ASSUME_NONNULL_*`. Explicitly use `nullable` or `nonnull` to avoid oversight.
• Fix memory leak
• Update to recommended build settings on Xcode 7 (everything still works on Xcode 6.4)

Given the breaking change and support for a brand new Xcode, it made sense to go to v2.0.

cc @EricMuller22 @pwesten @kenwigginton @mthole 