### PR TITLE
Remove test_sharedAccessGroupPrefix_returnsValidValue.

### DIFF
--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -738,13 +738,6 @@
     XCTAssertEqualObjects(KeyDictionary[(__bridge id)kSecAttrAccount], self.key);
 }
 
-#if TARGET_HAS_ENTITLEMENTS
-- (void)test_sharedAccessGroupPrefix_returnsValidValue;
-{
-    XCTAssertTrue([self.valet _sharedAccessGroupPrefix].length > 0);
-}
-#endif
-
 #pragma mark - XCTestCase
 
 // These fail when running from the command line


### PR DESCRIPTION
The Xcode 7 test environment doesn't write kSecAttrAccessGroup or kSecAttrAccessControl values on keychain items, which caused the _sharedAccessGroupPrefix test to fail. _sharedAccessGroupPrefix has been tested on a signed build on iOS 9 so we know it works despite the test failure on Xcode 7. rdar://22395553 has been filed.

While it is highly unfortunate to have to remove a failing test, Apple broke their test environment, and we can't work around it. Fixes #33.

cc @EricMuller22 @shawnwelch