### PR TITLE
Expose a way to override kSecAttrService

### DIFF
--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -70,10 +70,13 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 /// @see VALAccessibility
 - (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility NS_DESIGNATED_INITIALIZER;
 
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility serviceAttribute:(nonnull NSString *)serviceAttribute NS_DESIGNATED_INITIALIZER;
+
 /// Creates a Valet that reads/writes keychain elements that can be shared across applications written by the same development team.
 /// @param sharedAccessGroupIdentifier This must correspond with the value for keychain-access-groups in your Entitlements file.
 /// @see VALAccessibility
 - (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility serviceAttribute:(nonnull NSString *)serviceAttribute NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)init NS_UNAVAILABLE;
 + (nullable instancetype)new NS_UNAVAILABLE;

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -209,6 +209,48 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
     return [[self class] _sharedValetForValet:self];
 }
 
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility serviceAttribute:(nonnull NSString *)serviceAttribute;
+{
+    VALCheckCondition(identifier.length > 0, nil, @"Valet requires an identifier");
+    VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
+    VALCheckCondition(serviceAttribute.length > 0, nil, @"Valet requires a valid serviceAttribute");
+
+    self = [super init];
+    if (self != nil) {
+        NSMutableDictionary *baseQuery = [self mutableBaseQueryWithIdentifier:@"tmp" initializer:_cmd accessibility:accessibility];
+        baseQuery[(__bridge id)kSecAttrService] = serviceAttribute;
+        
+        _baseQuery = [baseQuery copy];
+        _identifier = [identifier copy];
+        _sharedAcrossApplications = NO;
+        _accessibility = accessibility;
+        _lockForSetAndRemoveOperations = [NSLock new];
+    }
+    
+    return [[self class] _sharedValetForValet:self];
+}
+
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility serviceAttribute:(nonnull NSString *)serviceAttribute;
+{
+    VALCheckCondition(sharedAccessGroupIdentifier.length > 0, nil, @"Valet requires a sharedAccessGroupIdentifier");
+    VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
+    
+    self = [super init];
+    if (self != nil) {
+        NSMutableDictionary *baseQuery = [self mutableBaseQueryWithIdentifier:sharedAccessGroupIdentifier initializer:_cmd accessibility:accessibility];
+        baseQuery[(__bridge id)kSecAttrAccessGroup] = [NSString stringWithFormat:@"%@.%@", [self _sharedAccessGroupPrefix], sharedAccessGroupIdentifier];
+        baseQuery[(__bridge id)kSecAttrService] = serviceAttribute;
+        
+        _baseQuery = [baseQuery copy];
+        _identifier = [sharedAccessGroupIdentifier copy];
+        _sharedAcrossApplications = YES;
+        _accessibility = accessibility;
+        _lockForSetAndRemoveOperations = [NSLock new];
+    }
+    
+    return [[self class] _sharedValetForValet:self];
+}
+
 #pragma mark - NSObject
 
 - (BOOL)isEqual:(id)object;
@@ -224,7 +266,7 @@ OSStatus VALAtomicSecItemDelete(CFDictionaryRef query)
 
 - (NSString *)description;
 {
-    return [NSString stringWithFormat:@"%@: %@ %@%@", [super description], self.identifier, (self.sharedAcrossApplications ? @"Shared " : @""), VALStringForAccessibility(self.accessibility)];
+    return [NSString stringWithFormat:@"%@: %@ %@%@ %@", [super description], self.identifier, (self.sharedAcrossApplications ? @"Shared " : @""), VALStringForAccessibility(self.accessibility), self.secServiceIdentifier];
 }
 
 #pragma mark - NSCopying


### PR DESCRIPTION
Legacy app may have created shared keychain using a different service than the hardcoded one. This allows to specify it.