### PR TITLE
Add support for remapping keys during migration

### DIFF
--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -119,9 +119,13 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 /// @see VALMigrationError
 /// @note The keychain is not modified if a failure occurs.
 - (nullable NSError *)migrateObjectsMatchingQuery:(nonnull NSDictionary *)secItemQuery removeOnCompletion:(BOOL)remove;
+/// @param keyMap An optional <NSString, NSString> dictionary with string replacements for kSecAttrAccount values
+- (nullable NSError *)migrateObjectsMatchingQuery:(nonnull NSDictionary *)secItemQuery keyMap:(nullable NSDictionary *)keyMap removeOnCompletion:(BOOL)remove;
 /// Migrates objects from the passed-in Valet into the receiving Valet instance.
 /// @return An error if the operation failed. Error domain will be <code>VALMigrationErrorDomain</code>, and codes will be of type <code>VALMigrationError</code>
 /// @see VALMigrationError
 - (nullable NSError *)migrateObjectsFromValet:(nonnull VALValet *)valet removeOnCompletion:(BOOL)remove;
+/// @param keyMap An optional <NSString, NSString> dictionary with string replacements for kSecAttrAccount values
+- (nullable NSError *)migrateObjectsFromValet:(nonnull VALValet *)valet keyMap:(nullable NSDictionary *)keyMap removeOnCompletion:(BOOL)remove;
 
 @end

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -599,7 +599,7 @@
     XCTAssertEqual([self.valet migrateObjectsMatchingQuery:queryWithConflict removeOnCompletion:NO].code, VALMigrationErrorDuplicateKeyInQueryResult);
 }
 
-- (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesSingleKeyValuePairSuccessfully;
+- (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesSingleKeyValuePairSuccessfullyWithoutRemovingOnCompletion;
 {
     VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet_Single_Key" accessibility:VALAccessibilityAfterFirstUnlock];
     [self.additionalValets addObject:otherValet];
@@ -614,6 +614,27 @@
     
     for (NSString *key in keyStringPairToMigrateMap) {
         XCTAssertEqualObjects([self.valet stringForKey:key], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
+    }
+}
+
+- (void)test_migrateObjectsFromValetMappingKeysRemoveOnCompletion_migratesSingleKeyValuePairSuccessfullyWithoutRemovingOnCompletion;
+{
+    VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet_Single_Key" accessibility:VALAccessibilityAfterFirstUnlock];
+    [self.additionalValets addObject:otherValet];
+    
+    NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar" };
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+    }
+    
+    NSDictionary *keyMap = @{ @"foo" : @"buzz" };
+    
+    XCTAssertNil([self.valet migrateObjectsFromValet:otherValet keyMap:keyMap removeOnCompletion:NO]);
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertEqualObjects([self.valet stringForKey:keyMap[key]], keyStringPairToMigrateMap[key]);
         XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
     }
 }
@@ -637,6 +658,55 @@
     }
 }
 
+- (void)test_migrateObjectsFromValetMappingKeysRemoveOnCompletion_migratesDataSuccessfullyWithoutRemovingOnCompletion;
+{
+    VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
+    [self.additionalValets addObject:otherValet];
+    
+    NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+    }
+    
+    NSDictionary *keyMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+
+    XCTAssertNil([self.valet migrateObjectsFromValet:otherValet keyMap:keyMap removeOnCompletion:NO]);
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertEqualObjects([self.valet stringForKey:keyMap[key]], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
+    }
+}
+
+- (void)test_migrateObjectsFromValetMappingKeysRemoveOnCompletion_migratesDataSuccessfullyPartiallyRemappingKeysWithoutRemovingOnCompletion;
+{
+    VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
+    [self.additionalValets addObject:otherValet];
+    
+    NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+    }
+    
+    NSDictionary *partialKeyMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite" };
+
+    XCTAssertNil([self.valet migrateObjectsFromValet:otherValet keyMap:partialKeyMap removeOnCompletion:NO]);
+    
+    for (NSString *key in partialKeyMap) {
+        XCTAssertEqualObjects([self.valet stringForKey:partialKeyMap[key]], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
+    }
+    
+    NSMutableDictionary *unmappedKeyStringPair = [keyStringPairToMigrateMap mutableCopy];
+    [unmappedKeyStringPair removeObjectsForKeys:partialKeyMap.allKeys];
+    for (NSString *key in unmappedKeyStringPair) {
+        XCTAssertEqualObjects([self.valet stringForKey:key], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
+    }
+}
+
 - (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenRemovingOnCompletion;
 {
     VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
@@ -652,6 +722,28 @@
     
     for (NSString *key in keyStringPairToMigrateMap) {
         XCTAssertEqualObjects([self.valet stringForKey:key], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], nil);
+    }
+}
+
+
+- (void)test_migrateObjectsFromValetMappingKeysRemoveOnCompletion_migratesDataSuccessfullyWhenRemovingOnCompletion;
+{
+    VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
+    [self.additionalValets addObject:otherValet];
+    
+    NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+    }
+    
+    NSDictionary *keyMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+    
+    XCTAssertNil([self.valet migrateObjectsFromValet:otherValet keyMap:keyMap removeOnCompletion:YES]);
+    
+    for (NSString *key in keyStringPairToMigrateMap) {
+        XCTAssertEqualObjects([self.valet stringForKey:keyMap[key]], keyStringPairToMigrateMap[key]);
         XCTAssertEqualObjects([otherValet stringForKey:key], nil);
     }
 }


### PR DESCRIPTION
When migrating from an old keychain to a Valet, sometimes we may want to remap the old identifiers to different ones.