### PR TITLE
Compare kSecUseAuthenticationUI to nil rather than address of to NULL

### DIFF
--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -89,7 +89,10 @@
     NSDictionary *options = nil;
     
 #if VAL_IOS_9_OR_LATER
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
     if (&kSecUseAuthenticationUI != NULL) {
+#pragma GCC diagnostic pop
         options = @{ (__bridge id)kSecUseAuthenticationUI : (__bridge id)kSecUseAuthenticationUIFail };
     } else {
 #pragma GCC diagnostic push


### PR DESCRIPTION
The current code, with options `[-Werror,-Wtautological-pointer-compare]` set, will produce the following error, as the condition at line 92 of Valet/VALSecureEnclaveValet.m will always evaluate as true:

```
    error: comparison of address of 'kSecUseAuthenticationUI' not equal to a null pointer is always true
```

This PR changes the check to test the value of this variable rather than the address of the pointer, allowing my iOS 9 project to compile correctly.