### PR TITLE
Add a sub-Valet which handles ONLY fingerprints, no PIN fallback.

### DIFF
--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AA0832BDED78449C07C939B /* VALSecureEnclaveBiometricValet.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA08F95D9944F0176CE19AF /* VALSecureEnclaveBiometricValet.m */; };
+		1AA08B596467D7533CD17C6E /* VALSecureEnclaveBiometricValet.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA08330770D9270B7B37E4B /* VALSecureEnclaveBiometricValet.h */; };
 		26E682841BA8B42100EFF4EA /* Valet.h in Headers */ = {isa = PBXBuildFile; fileRef = EA1E1F861A8C46080067C991 /* Valet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26F06A531BA8B53100E039CD /* VALSynchronizableValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26F06A541BA8B53C00E039CD /* VALSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1E1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -79,6 +81,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1AA08330770D9270B7B37E4B /* VALSecureEnclaveBiometricValet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VALSecureEnclaveBiometricValet.h; sourceTree = "<group>"; };
+		1AA08F95D9944F0176CE19AF /* VALSecureEnclaveBiometricValet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VALSecureEnclaveBiometricValet.m; sourceTree = "<group>"; };
 		26E6827C1BA8B3F900EFF4EA /* Valet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Valet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26E6828A1BA8B4B200EFF4EA /* Valet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Valet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26E682921BA8B4D200EFF4EA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -202,6 +206,8 @@
 				EAEEAC1F1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m */,
 				EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */,
 				EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */,
+				1AA08F95D9944F0176CE19AF /* VALSecureEnclaveBiometricValet.m */,
+				1AA08330770D9270B7B37E4B /* VALSecureEnclaveBiometricValet.h */,
 			);
 			path = Valet;
 			sourceTree = "<group>";
@@ -306,6 +312,7 @@
 				EAEAA8AC1B16864D00F7AA98 /* Valet.h in Headers */,
 				EAEEAC271AB7BC5700EDB6E3 /* VALValet_Protected.h in Headers */,
 				EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */,
+				1AA08B596467D7533CD17C6E /* VALSecureEnclaveBiometricValet.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -561,6 +568,7 @@
 				EAEEAC1D1AB7B84000EDB6E3 /* VALSynchronizableValet.m in Sources */,
 				EAEEAC1A1AB7B83300EDB6E3 /* VALValet.m in Sources */,
 				EAEEAC201AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m in Sources */,
+				1AA0832BDED78449C07C939B /* VALSecureEnclaveBiometricValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Valet/VALSecureEnclaveBiometricValet.h
+++ b/Valet/VALSecureEnclaveBiometricValet.h
@@ -1,0 +1,51 @@
+//
+//  Created by Nic Wise on 9/01/16.
+//  Copyright 2016 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "VALSecureEnclaveValet.h"
+
+typedef NS_ENUM(NSUInteger, VALTouchIdSensitivity) {
+    /// Valet data can only be accessed with a fingerprint, not the device PIN
+            VALTouchIdFingerPrintAny __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_9_0) = 1,
+    /// Valet data can only be accessed with _the current set_ of fingerprints, and never the pin
+            VALTouchIdFingerPrintCurrentSetOnly __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_9_0)
+};
+
+
+/// Reads and writes keychain elements that are stored on the Secure Enclave
+// (supported on iOS 8.0 or later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly.
+// Accessing or modifying these items will require the user to confirm their presence via Touch ID or passcode entry.
+// If no passcode is set on the device, the below methods will fail.
+// Data is removed from the Secure Enclave when the user removes a passcode from the device.
+// Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
+//
+//
+// Extends the base VALSecureEnclaveValet to disallow the fallback to PIN, and to control invalidating the
+// item when the fingerprint list changes.
+NS_CLASS_AVAILABLE_IOS(9_0)
+@interface VALSecureEnclaveBiometricValet : VALSecureEnclaveValet
+
+/// Creates a Valet that reads/writes Secure Enclave keychain elements.
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier sensitivity:(VALTouchIdSensitivity)sensitivity;
+
+/// Creates a Valet that reads/writes Secure Enclave keychain elements that can be shared across applications written by the same development team.
+/// @param sharedAccessGroupIdentifier This must correspond with the value for keychain-access-groups in your Entitlements file.
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier sensitivity:(VALTouchIdSensitivity)sensitivity;
+
+
+
+@end

--- a/Valet/VALSecureEnclaveBiometricValet.m
+++ b/Valet/VALSecureEnclaveBiometricValet.m
@@ -1,0 +1,73 @@
+//
+//  VALSecureEnclaveBiometricValet.m
+//  Valet
+//
+//  Created by Nic Wise on 01/09/16.
+//  Copyright 2015 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "VALSecureEnclaveBiometricValet.h"
+
+#import "VALValet_Protected.h"
+
+
+@implementation VALSecureEnclaveBiometricValet {
+
+}
+
+//this feels hacky, but the baseQuery is setup before the init returns, so I need to store it somewhere
+static VALTouchIdSensitivity baseSensitivity;
+
+- (instancetype)initWithIdentifier:(NSString *)identifier sensitivity:(VALTouchIdSensitivity)sensitivity {
+    baseSensitivity = sensitivity;
+
+    self = [super initWithIdentifier:identifier];
+    return self;
+}
+
+- (instancetype)initWithSharedAccessGroupIdentifier:(NSString *)sharedAccessGroupIdentifier sensitivity:(VALTouchIdSensitivity)sensitivity {
+    baseSensitivity = sensitivity;
+
+    self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier];
+    return self;
+}
+
+
+- (nonnull NSMutableDictionary *)mutableBaseQueryWithIdentifier:(nonnull NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
+{
+
+    NSMutableDictionary *baseQuery = [super mutableBaseQueryWithIdentifier:identifier initializer:initializer accessibility:accessibility];
+    [baseQuery removeObjectForKey:(__bridge id)kSecAttrAccessControl];
+
+    baseQuery[(__bridge id)kSecAttrAccessControl] = (__bridge_transfer id)SecAccessControlCreateWithFlags(
+        kCFAllocatorDefault,
+        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+        [self touchIdAccessControl],
+        NULL);
+
+    return baseQuery;
+}
+
+- (enum SecAccessControlCreateFlags) touchIdAccessControl {
+    switch (baseSensitivity) {
+        case VALTouchIdFingerPrintCurrentSetOnly:
+            return kSecAccessControlTouchIDCurrentSet;
+        default:
+            return kSecAccessControlTouchIDAny;
+
+    }
+}
+
+@end

--- a/ValetTouchIDTest/ValetSecureElementTestViewController.m
+++ b/ValetTouchIDTest/ValetSecureElementTestViewController.m
@@ -41,7 +41,7 @@
 {
     [super viewDidLoad];
 
-    self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence"];
+    self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"UserPresence"];
 
     //iOS 9 - restrict it ONLY the fingerprint, and invalidate if the set of prints change
     //self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence" sensitivity:VALTouchIdFingerPrintCurrentSetOnly];

--- a/ValetTouchIDTest/ValetSecureElementTestViewController.m
+++ b/ValetTouchIDTest/ValetSecureElementTestViewController.m
@@ -21,6 +21,7 @@
 #import <Valet/VALSecureEnclaveValet.h>
 
 #import "ValetSecureElementTestViewController.h"
+#import "VALSecureEnclaveBiometricValet.h"
 
 
 @interface ValetSecureElementTestViewController ()
@@ -39,8 +40,12 @@
 - (void)viewDidLoad;
 {
     [super viewDidLoad];
-    
-    self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"UserPresence"];
+
+    //self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence"];
+
+    //iOS 9 - restrict it ONLY the fingerprint, and invalidate if the set of prints change
+    self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence" sensitivity:VALTouchIdFingerPrintCurrentSetOnly];
+
     self.username = @"CustomerPresentProof";
 }
 

--- a/ValetTouchIDTest/ValetSecureElementTestViewController.m
+++ b/ValetTouchIDTest/ValetSecureElementTestViewController.m
@@ -41,10 +41,10 @@
 {
     [super viewDidLoad];
 
-    //self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence"];
+    self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence"];
 
     //iOS 9 - restrict it ONLY the fingerprint, and invalidate if the set of prints change
-    self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence" sensitivity:VALTouchIdFingerPrintCurrentSetOnly];
+    //self.secureEnclaveValet = [[VALSecureEnclaveBiometricValet alloc] initWithIdentifier:@"UserPresence" sensitivity:VALTouchIdFingerPrintCurrentSetOnly];
 
     self.username = @"CustomerPresentProof";
 }


### PR DESCRIPTION
PR / changes which allow for fingerprint-only Secure Enclave to be used - no PIN fallback.

Some info [here](http://fastchicken.co.nz/2016/01/08/valet-keychain-done-right/) as to why.

I dont love the static in the class, for the baseAccessibility, but it needs to be set/stored before the super init it called, and I'm not sure how else to pass it in.