### PR TITLE
Valet to 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ script:
     - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.10 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet-iOS" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet-Mac" -sdk iphonesimulator -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet-Mac" -sdk macosx10.10 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build
     - pod lib lint --verbose --fail-fast

--- a/Other/ValetDefines.h
+++ b/Other/ValetDefines.h
@@ -38,11 +38,6 @@
         } \
     } while(0)
 
-/// Compile flag for building against iOS 8.
-#define VAL_IOS_8_OR_LATER (TARGET_OS_IPHONE && __IPHONE_8_0)
-
-/// Compile flag for building against iOS 9.
-#define VAL_IOS_9_OR_LATER (TARGET_OS_IPHONE && __IPHONE_9_0)
 
 /// Error returned from Security API when the application is not entitled to perform the requested action.
 #define errSecMissingEntitlement -34018

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Valet’s API for securely reading and writing data is similar to that of an NSM
 
 ### Sharing Secrets Among Multiple Applications
 
-```
+```objc
 VALValet *mySharedValet = [[VALValet alloc] initWithSharedAccessGroupIdentifier:@"Druidia" accessibility:VALAccessibilityWhenUnlocked];
 ```
 
@@ -97,13 +97,13 @@ VALSynchronizableValet *mySynchronizableValet = [[VALSynchronizableValet alloc] 
 
 This instance can be used to store and retrieve data that can be retrieved by this app on other devices logged into the same iCloud account with iCloud Keychain enabled. `mySynchronizableValet` can not read or modify values in `myValet` or `mySharedValet` because `mySynchronizableValet` is of a different class type. If iCloud Keychain is not enabled on this device, secrets can still be read and written, but will not sync to other devices.
 
-### Protecting Secrets with Touch ID or iOS Passcode
+### Protecting Secrets with Touch ID or device Passcode
 
 ```objc
-VALSecureEnclaveValet *mySecureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"Druidia"];
+VALSecureEnclaveValet *mySecureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"Druidia" accessControl:VALAccessControlUserPresence];
 ```
 
-This instance can be used to store and retrieve data in the Secure Enclave (supported on iOS 8.0 or later). Reading or modifying items in this Valet will require the user to confirm their presence via Touch ID or by entering their iOS passcode. If no passcode is set on the device, this instance will be unable to access or store data. Data is removed from the Secure Enclave when the user removes a passcode from the device. Storing data using VALSecureEnclaveValet is the most secure way to store data on iOS.
+This instance can be used to store and retrieve data in the Secure Enclave (available on iOS 8.0 and later and Mac OS 10.11 and later). Reading or modifying items in this Valet will require the user to confirm their presence via Touch ID on iOS or by entering their device passcode. *If no passcode is set on the device, this instance will be unable to access or store data.* Data is removed from the Secure Enclave when the user removes a passcode from the device. Storing data using VALSecureEnclaveValet is the most secure way to store data on either iOS or Mac OS.
 
 ### Migrating Existing Keychain Values into Valet
 

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,12 +1,14 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.0.7'
+  s.version  = '2.1.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
   s.source_files = 'Valet/*.{h,m}', 'Other/*.{h,m}'
+  s.public_header_files = 'Valet/*.h'
+  s.exclude_files = 'Valet/*_Protected.h'
   s.frameworks = 'Security'
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.10'

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -27,13 +27,15 @@
 		26F06A921BA8BC9700E039CD /* VALValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC191AB7B83300EDB6E3 /* VALValet.m */; };
 		EA1E1F8F1A8C46090067C991 /* libValet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E1F831A8C46080067C991 /* libValet.a */; };
 		EA1E1FA01A8C48560067C991 /* ValetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E1F9F1A8C48560067C991 /* ValetTests.m */; };
+		EA7756041C487783009C5C92 /* VALSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1E1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA7756051C4877A3009C5C92 /* VALSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1F1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m */; };
 		EAEAA88D1B167A8700F7AA98 /* libValet.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EAEAA8821B167A8600F7AA98 /* libValet.dylib */; };
 		EAEAA8991B16813100F7AA98 /* ValetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E1F9F1A8C48560067C991 /* ValetTests.m */; };
 		EAEAA89E1B16818400F7AA98 /* Valet.h in Headers */ = {isa = PBXBuildFile; fileRef = EA1E1F861A8C46080067C991 /* Valet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA89F1B16818400F7AA98 /* VALValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC181AB7B83300EDB6E3 /* VALValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA8A11B16818400F7AA98 /* VALSynchronizableValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEAA8A21B16818E00F7AA98 /* VALValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC231AB7BA0C00EDB6E3 /* VALValet_Protected.h */; };
-		EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; };
 		EAEAA8A41B16821D00F7AA98 /* VALValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC191AB7B83300EDB6E3 /* VALValet.m */; };
 		EAEAA8A61B16821D00F7AA98 /* VALSynchronizableValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */; };
 		EAEAA8AC1B16864D00F7AA98 /* Valet.h in Headers */ = {isa = PBXBuildFile; fileRef = EA1E1F861A8C46080067C991 /* Valet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -41,7 +43,7 @@
 		EAEEAC1D1AB7B84000EDB6E3 /* VALSynchronizableValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */; };
 		EAEEAC201AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEEAC1F1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m */; };
 		EAEEAC271AB7BC5700EDB6E3 /* VALValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC231AB7BA0C00EDB6E3 /* VALValet_Protected.h */; };
-		EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC251AB7BA9800EDB6E3 /* ValetDefines.h */; };
 		EAEEAC2A1AB7BD4800EDB6E3 /* VALValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC181AB7B83300EDB6E3 /* VALValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEEAC2B1AB7BD7400EDB6E3 /* VALSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1E1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EAEEAC2C1AB7BD7900EDB6E3 /* VALSynchronizableValet.h in Headers */ = {isa = PBXBuildFile; fileRef = EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -289,6 +291,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEAA89E1B16818400F7AA98 /* Valet.h in Headers */,
+				EA7756041C487783009C5C92 /* VALSecureEnclaveValet.h in Headers */,
 				EAEAA8A21B16818E00F7AA98 /* VALValet_Protected.h in Headers */,
 				EAEAA8A11B16818400F7AA98 /* VALSynchronizableValet.h in Headers */,
 				EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */,
@@ -577,6 +580,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEAA8A61B16821D00F7AA98 /* VALSynchronizableValet.m in Sources */,
+				EA7756051C4877A3009C5C92 /* VALSecureEnclaveValet.m in Sources */,
 				EAEAA8A41B16821D00F7AA98 /* VALValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSUInteger, VALAccessibility) {
     VALAccessibilityAlways,
     
     /// Valet data can only be accessed while the device is unlocked. This class is only available if a passcode is set on the device. This is recommended for items that only need to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device. No items can be stored in this class on devices without a passcode. Disabling the device passcode will cause all items in this class to be deleted.
-    VALAccessibilityWhenPasscodeSetThisDeviceOnly __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0),
+    VALAccessibilityWhenPasscodeSetThisDeviceOnly NS_ENUM_AVAILABLE(10_10, 8_0),
     /// Valet data can only be accessed while the device is unlocked. This is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
     VALAccessibilityWhenUnlockedThisDeviceOnly,
     /// Valet data can only be accessed once the device has been unlocked after a restart. This is recommended for items that need to be accessible by background applications. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.

--- a/Valet/VALValet_Protected.h
+++ b/Valet/VALValet_Protected.h
@@ -21,26 +21,31 @@
 #import <Valet/VALValet.h>
 
 
-NS_ASSUME_NONNULL_BEGIN
-
-
-extern NSString *VALStringForAccessibility(VALAccessibility accessibility);
+extern NSString * __nonnull VALStringForAccessibility(VALAccessibility accessibility);
 
 
 @interface VALValet ()
 
-- (NSMutableDictionary *)mutableBaseQueryWithIdentifier:(NSString *)identifier initializer:(SEL)initializer accessibility:(VALAccessibility)accessibility;
+/// Ensures the atomicity for set and remove operations by limiting ourselves to one instance per configuration.
+/// @return An existing valet object with the same configuration as the valet provided if one exists, or the passed in valet.
++ (nonnull id)sharedValetForValet:(nonnull VALValet *)valet;
 
-- (BOOL)setObject:(NSData *)value forKey:(NSString *)key options:(nullable NSDictionary *)options;
-- (nullable NSData *)objectForKey:(NSString *)key options:(nullable NSDictionary *)options;
-- (BOOL)setString:(NSString *)string forKey:(NSString *)key options:(nullable NSDictionary *)options;
-- (nullable NSString *)stringForKey:(NSString *)key options:(nullable NSDictionary *)options;
-- (OSStatus)containsObjectForKey:(NSString *)key options:(nullable NSDictionary *)options;
-- (NSSet *)allKeysWithOptions:(nullable NSDictionary *)options;
-- (BOOL)removeObjectForKey:(NSString *)key options:(nullable NSDictionary *)options;
+/// Creates a base query given the injected properties. Do not override.
++ (nullable NSMutableDictionary *)mutableBaseQueryWithIdentifier:(nonnull NSString *)identifier accessibility:(VALAccessibility)accessibility initializer:(nonnull SEL)initializer;
+
+/// Creates a base query for shared access group Valets given the injected properties. Do not override.
++ (nullable NSMutableDictionary *)mutableBaseQueryWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility initializer:(nonnull SEL)initializer;
+
+/// Stores the root query to be used in all SecItem queries.
+@property (nonnull, copy, readonly) NSDictionary *baseQuery;
+
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
+- (nullable NSData *)objectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
+- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
+- (nullable NSString *)stringForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
+- (OSStatus)containsObjectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
+- (nonnull NSSet *)allKeysWithOptions:(nullable NSDictionary *)options;
+- (BOOL)removeObjectForKey:(nonnull NSString *)key options:(nullable NSDictionary *)options;
 - (BOOL)removeAllObjectsWithOptions:(nullable NSDictionary *)options;
 
 @end
-
-
-NS_ASSUME_NONNULL_END

--- a/ValetTouchIDTest/ValetSecureElementTestViewController.m
+++ b/ValetTouchIDTest/ValetSecureElementTestViewController.m
@@ -40,7 +40,7 @@
 {
     [super viewDidLoad];
     
-    self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"UserPresence"];
+    self.secureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"UserPresence" accessControl:VALAccessControlUserPresence];
     self.username = @"CustomerPresentProof";
 }
 


### PR DESCRIPTION
- VALSecureEnclaveValet can now store keychain elements under different AccessControl rules (UserPresence, TouchIDAnyFingerprint, TouchIDCurrentFingerprintSet, DevicePasscode)
- VALSecureEnclaveValet available on Mac OS 10.11
- Properly made VALValet_Protected.h private under CocoaPods (it was already private via submodules and Carthage)
- Properly made ValetDefines.h private

Fixes #48

cc @EricMuller22 @nicwise 