### PR TITLE
SharedAccessIdentifier Valets should work in the simulator

### DIFF
--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.2.1'
+  s.version  = '2.2.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -225,7 +225,7 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
         SEL const backwardsCompatibleInitializer = @selector(initWithSharedAccessGroupIdentifier:accessibility:);
 #if TARGET_IPHONE_SIMULATOR
         /*
-         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
          Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
          */

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -223,7 +223,7 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
     if (self != nil) {
         SEL const backwardsCompatibleInitializer = @selector(initWithSharedAccessGroupIdentifier:accessibility:);
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR
         /*
          Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -223,9 +223,20 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
     if (self != nil) {
         SEL const backwardsCompatibleInitializer = @selector(initWithSharedAccessGroupIdentifier:accessibility:);
+#if TARGET_IPHONE_SIMULATOR
+        /*
+         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
+         Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
+         */
+        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:sharedAccessGroupIdentifier
+                                                                              accessibility:accessibility
+                                                                                initializer:backwardsCompatibleInitializer];
+#else
         NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
                                                                                                accessibility:accessibility
                                                                                                  initializer:backwardsCompatibleInitializer];
+#endif
         [[self class] _augmentBaseQuery:baseQuery
                           accessControl:accessControl];
         _baseQuery = baseQuery;

--- a/Valet/VALSynchronizableValet.m
+++ b/Valet/VALSynchronizableValet.m
@@ -82,9 +82,20 @@
     
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
     if (self != nil) {
+#if TARGET_IPHONE_SIMULATOR
+        /*
+         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
+         Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
+         */
+        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:sharedAccessGroupIdentifier
+                                                                              accessibility:accessibility
+                                                                                initializer:_cmd];
+#else
         NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
                                                                                                accessibility:accessibility
                                                                                                  initializer:_cmd];
+#endif
         [[self class] _augmentBaseQuery:baseQuery];
         _baseQuery = baseQuery;
     }

--- a/Valet/VALSynchronizableValet.m
+++ b/Valet/VALSynchronizableValet.m
@@ -84,7 +84,7 @@
     if (self != nil) {
 #if TARGET_IPHONE_SIMULATOR
         /*
-         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
          Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
          */

--- a/Valet/VALSynchronizableValet.m
+++ b/Valet/VALSynchronizableValet.m
@@ -36,7 +36,7 @@
 #pragma clang diagnostic ignored "-Wtautological-compare"
     
 #define SUPPORTS_SYNCHRONIZABLE_KEYCHAIN_MAC (TARGET_OS_MAC && __MAC_10_9)
-#define SUPPORTS_SYNCHRONIZABLE_KEYCHAIN_IOS (TARGET_OS_IPHONE && (__IPHONE_8_2 || (__IPHONE_7_0 && !TARGET_IPHONE_SIMULATOR)))
+#define SUPPORTS_SYNCHRONIZABLE_KEYCHAIN_IOS (TARGET_OS_IPHONE && (__IPHONE_8_2 || (__IPHONE_7_0 && !(TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR))))
     
 #if SUPPORTS_SYNCHRONIZABLE_KEYCHAIN_MAC || SUPPORTS_SYNCHRONIZABLE_KEYCHAIN_IOS
     return (&kSecAttrSynchronizable != NULL && &kSecAttrSynchronizableAny != NULL);
@@ -82,7 +82,7 @@
     
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
     if (self != nil) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR
         /*
          Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -262,7 +262,7 @@ OSStatus VALAtomicSecItemDelete(__nonnull CFDictionaryRef query)
     if (self != nil) {
 #if TARGET_IPHONE_SIMULATOR
         /*
-         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
          Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
          */

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -260,7 +260,7 @@ OSStatus VALAtomicSecItemDelete(__nonnull CFDictionaryRef query)
     
     self = [super init];
     if (self != nil) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR
         /*
          Access groups do not work on the simulator because apps built for the simulator aren't signed.
          Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -260,7 +260,16 @@ OSStatus VALAtomicSecItemDelete(__nonnull CFDictionaryRef query)
     
     self = [super init];
     if (self != nil) {
+#if TARGET_IPHONE_SIMULATOR
+        /*
+         Access groups do not work on the simulator becuase apps built for the simulator aren't signed.
+         Using kSecAttrAccessGroup in the simulator will cause SecItem calls to return -25243 (errSecNoAccessForItem).
+         Dropping the kSecAttrAccessGroup key/value pair does not cause problems in development, since all apps can see all keychain items on the simulator.
+         */
+        _baseQuery = [[self class] mutableBaseQueryWithIdentifier:sharedAccessGroupIdentifier accessibility:accessibility initializer:_cmd];
+#else
         _baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility initializer:_cmd];
+#endif
         
         _identifier = [sharedAccessGroupIdentifier copy];
         _sharedAcrossApplications = YES;

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -24,7 +24,7 @@
 
 
 // The iPhone simulator fakes entitlements, allowing us to test the iCloud Keychain (VALSynchronizableValet) code without writing a signed host app.
-#define TARGET_HAS_ENTITLEMENTS TARGET_IPHONE_SIMULATOR
+#define TARGET_HAS_ENTITLEMENTS (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR)
 
 
 @interface VALValet (Testing)


### PR DESCRIPTION
Found out the hard way today that shared access identifier Valets don't work in the simulator. This should fix.

cc @EricMuller22 @kongd