### PR TITLE
[2.2.2] Migration should not fail because `canAccessKeychain` has been called on both Valets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
-source 'https://rubygems.org'
-
-gem 'cocoapods', '0.39.0'
+source 'https://rubygems.org' do
+  gem 'cocoapods', '1.0.0'
+  gem 'activesupport', '~> 4.0'
+end

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.2.1'
+  s.version  = '2.2.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -747,6 +747,27 @@
     }
 }
 
+- (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenBothValetsHavePreviouslyCalled_canAccessKeychain;
+{
+    VALValet *otherValet = [[VALValet alloc] initWithIdentifier:@"Migrate_Me_To_Valet" accessibility:VALAccessibilityAfterFirstUnlock];
+    [self.additionalValets addObject:otherValet];
+    
+    NSDictionary *keyStringPairToMigrateMap = @{ @"foo" : @"bar", @"testing" : @"migration", @"is" : @"quite", @"entertaining" : @"if", @"you" : @"don't", @"screw" : @"up" };
+    
+    for (NSString *const key in keyStringPairToMigrateMap) {
+        XCTAssertTrue([otherValet setString:keyStringPairToMigrateMap[key] forKey:key]);
+    }
+    
+    XCTAssertTrue([self.valet canAccessKeychain]);
+    XCTAssertTrue([otherValet canAccessKeychain]);
+    XCTAssertNil([self.valet migrateObjectsFromValet:otherValet removeOnCompletion:NO]);
+    
+    for (NSString *const key in keyStringPairToMigrateMap) {
+        XCTAssertEqualObjects([self.valet stringForKey:key], keyStringPairToMigrateMap[key]);
+        XCTAssertEqualObjects([otherValet stringForKey:key], keyStringPairToMigrateMap[key]);
+    }
+}
+
 #if VAL_SECURE_ENCLAVE_SDK_AVAILABLE
 - (void)test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenMigratingToSecureEnclave;
 {


### PR DESCRIPTION
cc @EricMuller22 