### PR TITLE
Match nullability specifiers of NSObject initializers

### DIFF
--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.2.2'
+  s.version  = '2.2.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -200,16 +200,15 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
     
     VALAccessibility const accessibility = VALAccessibilityWhenPasscodeSetThisDeviceOnly;
     self = [super initWithIdentifier:identifier accessibility:accessibility];
-    if (self != nil) {
-        SEL const backwardsCompatibleInitializer = @selector(initWithIdentifier:accessibility:);
-        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier
-                                                                              accessibility:accessibility
-                                                                                initializer:backwardsCompatibleInitializer];
-        [[self class] _augmentBaseQuery:baseQuery
-                          accessControl:accessControl];
-        _baseQuery = baseQuery;
-        _accessControl = accessControl;
-    }
+
+    SEL const backwardsCompatibleInitializer = @selector(initWithIdentifier:accessibility:);
+    NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier
+                                                                          accessibility:accessibility
+                                                                            initializer:backwardsCompatibleInitializer];
+    [[self class] _augmentBaseQuery:baseQuery
+                      accessControl:accessControl];
+    _baseQuery = baseQuery;
+    _accessControl = accessControl;
     
     return [[self class] sharedValetForValet:self];
 }
@@ -221,16 +220,15 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
     
     VALAccessibility const accessibility = VALAccessibilityWhenPasscodeSetThisDeviceOnly;
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
-    if (self != nil) {
-        SEL const backwardsCompatibleInitializer = @selector(initWithSharedAccessGroupIdentifier:accessibility:);
-        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
-                                                                                               accessibility:accessibility
-                                                                                                 initializer:backwardsCompatibleInitializer];
-        [[self class] _augmentBaseQuery:baseQuery
-                          accessControl:accessControl];
-        _baseQuery = baseQuery;
-        _accessControl = accessControl;
-    }
+
+    SEL const backwardsCompatibleInitializer = @selector(initWithSharedAccessGroupIdentifier:accessibility:);
+    NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
+                                                                                           accessibility:accessibility
+                                                                                             initializer:backwardsCompatibleInitializer];
+    [[self class] _augmentBaseQuery:baseQuery
+                      accessControl:accessControl];
+    _baseQuery = baseQuery;
+    _accessControl = accessControl;
     
     return [[self class] sharedValetForValet:self];
 }

--- a/Valet/VALSynchronizableValet.m
+++ b/Valet/VALSynchronizableValet.m
@@ -64,13 +64,12 @@
     VALCheckCondition([[self class] supportsSynchronizableKeychainItems], nil, @"This device does not support synchronizing data to iCloud.");
     
     self = [super initWithIdentifier:identifier accessibility:accessibility];
-    if (self != nil) {
-        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier
-                                                                              accessibility:accessibility
-                                                                                initializer:_cmd];
-        [[self class] _augmentBaseQuery:baseQuery];
-        _baseQuery = baseQuery;
-    }
+
+    NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier
+                                                                          accessibility:accessibility
+                                                                            initializer:_cmd];
+    [[self class] _augmentBaseQuery:baseQuery];
+    _baseQuery = baseQuery;
     
     return [[self class] sharedValetForValet:self];
 }
@@ -81,13 +80,12 @@
     VALCheckCondition([[self class] supportsSynchronizableKeychainItems], nil, @"This device does not support synchronizing data to iCloud.");
     
     self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility];
-    if (self != nil) {
-        NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
-                                                                                               accessibility:accessibility
-                                                                                                 initializer:_cmd];
-        [[self class] _augmentBaseQuery:baseQuery];
-        _baseQuery = baseQuery;
-    }
+
+    NSMutableDictionary *const baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier
+                                                                                           accessibility:accessibility
+                                                                                             initializer:_cmd];
+    [[self class] _augmentBaseQuery:baseQuery];
+    _baseQuery = baseQuery;
     
     return [[self class] sharedValetForValet:self];
 }

--- a/Valet/VALValet.h
+++ b/Valet/VALValet.h
@@ -75,8 +75,8 @@ typedef NS_ENUM(NSUInteger, VALMigrationError) {
 /// @see VALAccessibility
 - (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessibility:(VALAccessibility)accessibility NS_DESIGNATED_INITIALIZER;
 
-- (nullable instancetype)init NS_UNAVAILABLE;
-+ (nullable instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 
 @property (nonnull, copy, readonly) NSString *identifier;
 @property (readonly, getter=isSharedAcrossApplications) BOOL sharedAcrossApplications;

--- a/Valet/VALValet.m
+++ b/Valet/VALValet.m
@@ -243,13 +243,12 @@ OSStatus VALAtomicSecItemDelete(__nonnull CFDictionaryRef query)
     VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
     
     self = [super init];
-    if (self != nil) {
-        _baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier accessibility:accessibility initializer:_cmd];
-        _identifier = [identifier copy];
-        _sharedAcrossApplications = NO;
-        _accessibility = accessibility;
-        _lockForSetAndRemoveOperations = [NSLock new];
-    }
+
+    _baseQuery = [[self class] mutableBaseQueryWithIdentifier:identifier accessibility:accessibility initializer:_cmd];
+    _identifier = [identifier copy];
+    _sharedAcrossApplications = NO;
+    _accessibility = accessibility;
+    _lockForSetAndRemoveOperations = [NSLock new];
     
     return [[self class] sharedValetForValet:self];
 }
@@ -260,14 +259,13 @@ OSStatus VALAtomicSecItemDelete(__nonnull CFDictionaryRef query)
     VALCheckCondition(accessibility > 0, nil, @"Valet requires a valid accessibility setting");
     
     self = [super init];
-    if (self != nil) {
-        _baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility initializer:_cmd];
-        
-        _identifier = [sharedAccessGroupIdentifier copy];
-        _sharedAcrossApplications = YES;
-        _accessibility = accessibility;
-        _lockForSetAndRemoveOperations = [NSLock new];
-    }
+
+    _baseQuery = [[self class] mutableBaseQueryWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessibility:accessibility initializer:_cmd];
+    
+    _identifier = [sharedAccessGroupIdentifier copy];
+    _sharedAcrossApplications = YES;
+    _accessibility = accessibility;
+    _lockForSetAndRemoveOperations = [NSLock new];
     
     return [[self class] sharedValetForValet:self];
 }


### PR DESCRIPTION
If you have the `CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION` warning enabled, the init/new methods on `Valet` produce the following warning:

```
Valet.framework/Headers/VALValet.h:78:1: Conflicting nullability specifier on return types, 'nullable' conflicts with existing specifier 'nonnull'
Valet.framework/Headers/VALValet.h:79:1: Conflicting nullability specifier on return types, 'nullable' conflicts with existing specifier 'nonnull'
```

Additionally, since `[NSObject init]` is now officially declared as not returning nil, I’ve removed the unneeded nil checks from the existing initializers.