### PR TITLE
Allow TouchID to be use on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.2
 before_script:
     - bundle install
 script:
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -destination "platform=iOS Simulator,OS=10.1,name=iPhone 7" -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.12 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test
-    - xcodebuild -project Valet.xcodeproj -scheme "Valet-iOS" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
+    - xcodebuild -project Valet.xcodeproj -scheme "Valet-iOS" -sdk iphonesimulator -destination "platform=iOS Simulator,OS=10.1,name=iPhone 7" -configuration Debug -PBXBuildsContinueAfterErrors=0 ACTIVE_ARCH_ONLY=0 build
     - xcodebuild -project Valet.xcodeproj -scheme "Valet-Mac" -sdk macosx10.12 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build
     - pod lib lint --verbose --fail-fast

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.2.3'
+  s.version  = '2.3.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet/VALSecureEnclaveValet.h
+++ b/Valet/VALSecureEnclaveValet.h
@@ -27,25 +27,25 @@
 
 typedef NS_ENUM(NSUInteger, VALAccessControl) {
     /// Access to keychain elements requires user presence verification via Touch ID or device Passcode. Keychain elements are still accessible by Touch ID even if fingers are added or removed. Touch ID does not have to be available or enrolled.
-    /// @version Available on iOS 8 or later, and Mac OS 10.11 or later.
+    /// @version Available on iOS 8 or later, and macOS 10.11 or later.
     VALAccessControlUserPresence = 1,
     
     /// Access to keychain elements requires user presence verification via any finger enrolled in Touch ID. Keychain elements are still accessible by Touch ID even if fingers are added or removed. Touch ID must be available and at least one finger must be enrolled.
-    /// @version Available on iOS 9 or later.
+    /// @version Available on iOS 9 or later, and macOS 10.12 or later.
     VALAccessControlTouchIDAnyFingerprint = 2,
     
     /// Access to keychain elements requires user presence verification via fingers currently enrolled in Touch ID. Previously written keychain elements become inaccessible when fingers are added or removed. Touch ID must be available and at least one finger must be enrolled.
-    /// @version Available on iOS 9 or later.
+    /// @version Available on iOS 9 or later, and macOS 10.12 or later.
     VALAccessControlTouchIDCurrentFingerprintSet = 3,
     
     /// Access to keychain elements requires user presence verification via device Passcode.
-    /// @version Available on iOS 9 or later, and Mac OS 10.11 or later.
+    /// @version Available on iOS 9 or later, and macOS 10.11 or later.
     VALAccessControlDevicePasscode = 4,
 };
 
 
-/// Reads and writes keychain elements that are stored on the Secure Enclave (available on iOS 8.0 and later and Mac OS 10.11 and later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. Accessing or modifying these keychain elements will require the user to confirm their presence via Touch ID or passcode entry. If no passcode is set on the device, the below methods will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device. Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
-/// @version Available on iOS 8 or later, and Mac OS 10.11 or later.
+/// Reads and writes keychain elements that are stored on the Secure Enclave (available on iOS 8.0 and later and macOS 10.11 and later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. Accessing or modifying these keychain elements will require the user to confirm their presence via Touch ID or passcode entry. If no passcode is set on the device, the below methods will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device. Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
+/// @version Available on iOS 8 or later, and macOS 10.11 or later.
 @interface VALSecureEnclaveValet : VALValet
 
 /// @return YES if Secure Enclave storage is supported on the current iOS version (8.0 and later).

--- a/Valet/VALSecureEnclaveValet.m
+++ b/Valet/VALSecureEnclaveValet.m
@@ -25,7 +25,7 @@
 
 
 /// Compiler flag for building against an SDK where VALAccessControlTouchIDAnyFingerprint and VALAccessControlTouchIDCurrentFingerprintSet are available.
-#define VAL_ACCESS_CONTROL_TOUCH_ID_SDK_AVAILABLE (TARGET_OS_IPHONE && __IPHONE_9_0)
+#define VAL_ACCESS_CONTROL_TOUCH_ID_SDK_AVAILABLE ((TARGET_OS_IPHONE && __IPHONE_9_0) || (TARGET_OS_MAC && __MAC_10_12))
 
 /// Compiler flag for building against an SDK where VALAccessControlDevicePasscode is available.
 #define VAL_ACCESS_CONTROL_DEVICE_PASSCODE_SDK_AVAILABLE ((TARGET_OS_IPHONE && __IPHONE_9_0) || (TARGET_OS_MAC && __MAC_10_11))
@@ -80,6 +80,18 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
 #endif
 }
 
++ (BOOL)_macOSSierraOrLater;
+{
+#if TARGET_OS_MAC && __MAC_10_12
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+    return (&kSecAttrTokenIDSecureEnclave != NULL);
+#pragma clang diagnostic pop
+#else
+    return NO;
+#endif
+}
+
 + (BOOL)_iOS8OrLater;
 {
 #if TARGET_OS_IPHONE
@@ -112,7 +124,7 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
             
         case VALAccessControlTouchIDAnyFingerprint:
         case VALAccessControlTouchIDCurrentFingerprintSet:
-            return [self _iOS9OrLater];
+            return [self _iOS9OrLater] || [self _macOSSierraOrLater];
             
         case VALAccessControlDevicePasscode:
             return ([self _iOS9OrLater] || [self _macOSElCapitanOrLater]);
@@ -252,7 +264,7 @@ NSString *__nonnull VALStringForAccessControl(VALAccessControl accessControl)
 {
     NSDictionary *options = nil;
     
-    // iOS 9 and Mac OS 10.11 use kSecUseAuthenticationUI, not kSecUseNoAuthenticationUI.
+    // iOS 9 and macOS 10.11 use kSecUseAuthenticationUI, not kSecUseNoAuthenticationUI.
 #if ((TARGET_OS_IPHONE && __IPHONE_9_0) || (TARGET_OS_MAC && __MAC_10_11))
     if ([[self class] _iOS9OrLater] || [[self class] _macOSElCapitanOrLater]) {
         options = @{ (__bridge id)kSecUseAuthenticationUI : (__bridge id)kSecUseAuthenticationUIFail };

--- a/ValetTests/ValetTests.m
+++ b/ValetTests/ValetTests.m
@@ -371,7 +371,7 @@
 #if !TARGET_OS_IPHONE
 - (void)test_setStringForKey_neutralizesMacOSAccessControlListVuln;
 {
-    // This test verifies that we are neutralizing the zero-day Mac OS X Access Control List vulnerability published here: https://drive.google.com/file/d/0BxxXk1d3yyuZOFlsdkNMSGswSGs/view
+    // This test verifies that we are neutralizing the zero-day macOS Access Control List vulnerability published here: https://drive.google.com/file/d/0BxxXk1d3yyuZOFlsdkNMSGswSGs/view
     
     NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
     BOOL macOS1010OrLater = (version.majorVersion == 10 && version.minorVersion >= 10);


### PR DESCRIPTION
Enables `SecureEnclaveValet`s to use TouchID on macOS!

Built on top of #102. Addresses #100.