### PR TITLE
Introducing VALSinglePromptSecureEnclaveValet

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ This instance can be used to store and retrieve data that can be retrieved by th
 VALSecureEnclaveValet *mySecureEnclaveValet = [[VALSecureEnclaveValet alloc] initWithIdentifier:@"Druidia" accessControl:VALAccessControlUserPresence];
 ```
 
-This instance can be used to store and retrieve data in the Secure Enclave (available on iOS 8.0 and later and Mac OS 10.11 and later). Reading or modifying items in this Valet will require the user to confirm their presence via Touch ID on iOS or by entering their device passcode. *If no passcode is set on the device, this instance will be unable to access or store data.* Data is removed from the Secure Enclave when the user removes a passcode from the device. Storing data using VALSecureEnclaveValet is the most secure way to store data on either iOS or Mac OS.
+This instance can be used to store and retrieve data in the Secure Enclave (available on iOS 8.0 and later and Mac OS 10.11 and later). Each time data is retrieved from this Valet, the user will be prompted to confirm their presence via Touch ID or by entering their device passcode. *If no passcode is set on the device, this instance will be unable to access or store data.* Data is removed from the Secure Enclave when the user removes a passcode from the device. Storing data using VALSecureEnclaveValet is the most secure way to store data on either iOS or Mac OS.
+
+```objc
+VALSinglePromptSecureEnclaveValet *mySecureEnclaveValet = [[VALSinglePromptSecureEnclaveValet alloc] initWithIdentifier:@"Druidia" accessControl:VALAccessControlUserPresence];
+```
+
+This instance also stores and retrieves data in the Secure Enclave, but does not require the user to confirm their presence each time data is retrieved. Instead, the user will be prompted to confirm their presence only on the first data retrieval. A `VALSinglePromptSecureEnclaveValet` instance can be forced to prompt the user on the next data retrieval by calling the instance method `requirePromptOnNextAccess`.
 
 ### Migrating Existing Keychain Values into Valet
 

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '2.3.0'
+  s.version  = '2.4.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -30,6 +30,18 @@
 		371150AD1E2962D8004A45D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 371150AB1E2962D8004A45D4 /* Main.storyboard */; };
 		371150AF1E2962D8004A45D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 371150AE1E2962D8004A45D4 /* Assets.xcassets */; };
 		371150B21E2962D8004A45D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 371150B01E2962D8004A45D4 /* LaunchScreen.storyboard */; };
+		371E38081E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */; };
+		371E38091E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */; };
+		371E380A1E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */; };
+		371E380B1E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */; };
+		371E380E1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		371E380F1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		371E38101E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		371E38111E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */ = {isa = PBXBuildFile; fileRef = 371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		371E38121E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = 371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */; };
+		371E38131E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = 371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */; };
+		371E38141E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = 371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */; };
+		371E38151E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */ = {isa = PBXBuildFile; fileRef = 371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */; };
 		AC89A3EC1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC89A3EB1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift */; };
 		AC89A3EE1CC82738009A7121 /* ValetTouchIDTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC89A3ED1CC82738009A7121 /* ValetTouchIDTestViewController.swift */; };
 		EA1E1F8F1A8C46090067C991 /* libValet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E1F831A8C46080067C991 /* libValet.a */; };
@@ -102,6 +114,9 @@
 		371150AE1E2962D8004A45D4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		371150B11E2962D8004A45D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		371150B31E2962D8004A45D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VALSecureEnclaveValet_Protected.h; sourceTree = "<group>"; };
+		371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VALSinglePromptSecureEnclaveValet.h; sourceTree = "<group>"; };
+		371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VALSinglePromptSecureEnclaveValet.m; sourceTree = "<group>"; };
 		37250B1D1E2DD55D008B4777 /* Valet iOS Test Host App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Valet iOS Test Host App.entitlements"; sourceTree = "<group>"; };
 		AC89A3EA1CC82426009A7121 /* ValetTouchIDTest-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ValetTouchIDTest-Bridging-Header.h"; sourceTree = "<group>"; };
 		AC89A3EB1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValetTouchIDTestAppDelegate.swift; sourceTree = "<group>"; };
@@ -241,7 +256,10 @@
 				EAEEAC231AB7BA0C00EDB6E3 /* VALValet_Protected.h */,
 				EAEEAC191AB7B83300EDB6E3 /* VALValet.m */,
 				EAEEAC1E1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.h */,
+				371E38071E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h */,
 				EAEEAC1F1AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m */,
+				371E380C1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h */,
+				371E380D1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m */,
 				EAEEAC1B1AB7B84000EDB6E3 /* VALSynchronizableValet.h */,
 				EAEEAC1C1AB7B84000EDB6E3 /* VALSynchronizableValet.m */,
 			);
@@ -303,9 +321,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				26E682841BA8B42100EFF4EA /* Valet.h in Headers */,
+				371E38101E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */,
 				26F06A551BA8B53F00E039CD /* VALValet.h in Headers */,
 				26F06A541BA8B53C00E039CD /* VALSecureEnclaveValet.h in Headers */,
 				26F06A531BA8B53100E039CD /* VALSynchronizableValet.h in Headers */,
+				371E380A1E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */,
 				26F06A5C1BA8B55D00E039CD /* ValetDefines.h in Headers */,
 				26F06A561BA8B54400E039CD /* VALValet_Protected.h in Headers */,
 			);
@@ -316,9 +336,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				26F06A571BA8B54E00E039CD /* Valet.h in Headers */,
+				371E38111E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */,
 				26F06A581BA8B55000E039CD /* VALValet.h in Headers */,
 				26F06A5A1BA8B55300E039CD /* VALSecureEnclaveValet.h in Headers */,
 				26F06A5B1BA8B55500E039CD /* VALSynchronizableValet.h in Headers */,
+				371E380B1E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */,
 				26F06A591BA8B55100E039CD /* VALValet_Protected.h in Headers */,
 				26F06A5D1BA8B56000E039CD /* ValetDefines.h in Headers */,
 			);
@@ -329,9 +351,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEAA89E1B16818400F7AA98 /* Valet.h in Headers */,
+				371E380F1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */,
 				EA7756041C487783009C5C92 /* VALSecureEnclaveValet.h in Headers */,
 				EAEAA8A21B16818E00F7AA98 /* VALValet_Protected.h in Headers */,
 				EAEAA8A11B16818400F7AA98 /* VALSynchronizableValet.h in Headers */,
+				371E38091E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */,
 				EAEAA8A31B1681F400F7AA98 /* ValetDefines.h in Headers */,
 				EAEAA89F1B16818400F7AA98 /* VALValet.h in Headers */,
 			);
@@ -342,9 +366,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEEAC2A1AB7BD4800EDB6E3 /* VALValet.h in Headers */,
+				371E380E1E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.h in Headers */,
 				EAEEAC2B1AB7BD7400EDB6E3 /* VALSecureEnclaveValet.h in Headers */,
 				EAEEAC2C1AB7BD7900EDB6E3 /* VALSynchronizableValet.h in Headers */,
 				EAEAA8AC1B16864D00F7AA98 /* Valet.h in Headers */,
+				371E38081E3713CB008A1C62 /* VALSecureEnclaveValet_Protected.h in Headers */,
 				EAEEAC271AB7BC5700EDB6E3 /* VALValet_Protected.h in Headers */,
 				EAEEAC281AB7BC5700EDB6E3 /* ValetDefines.h in Headers */,
 			);
@@ -627,6 +653,7 @@
 			files = (
 				26F06A8D1BA8BC8F00E039CD /* VALValet.m in Sources */,
 				26F06A8E1BA8BC9000E039CD /* VALSecureEnclaveValet.m in Sources */,
+				371E38141E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */,
 				26F06A8F1BA8BC9200E039CD /* VALSynchronizableValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -637,6 +664,7 @@
 			files = (
 				26F06A921BA8BC9700E039CD /* VALValet.m in Sources */,
 				26F06A911BA8BC9500E039CD /* VALSecureEnclaveValet.m in Sources */,
+				371E38151E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */,
 				26F06A901BA8BC9400E039CD /* VALSynchronizableValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -656,6 +684,7 @@
 			files = (
 				EAEEAC1D1AB7B84000EDB6E3 /* VALSynchronizableValet.m in Sources */,
 				EAEEAC1A1AB7B83300EDB6E3 /* VALValet.m in Sources */,
+				371E38121E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */,
 				EAEEAC201AB7B84E00EDB6E3 /* VALSecureEnclaveValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -674,6 +703,7 @@
 			files = (
 				EAEAA8A61B16821D00F7AA98 /* VALSynchronizableValet.m in Sources */,
 				EA7756051C4877A3009C5C92 /* VALSecureEnclaveValet.m in Sources */,
+				371E38131E3713DF008A1C62 /* VALSinglePromptSecureEnclaveValet.m in Sources */,
 				EAEAA8A41B16821D00F7AA98 /* VALValet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Valet/VALSecureEnclaveValet.h
+++ b/Valet/VALSecureEnclaveValet.h
@@ -44,11 +44,11 @@ typedef NS_ENUM(NSUInteger, VALAccessControl) {
 };
 
 
-/// Reads and writes keychain elements that are stored on the Secure Enclave (available on iOS 8.0 and later and macOS 10.11 and later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. Accessing or modifying these keychain elements will require the user to confirm their presence via Touch ID or passcode entry. If no passcode is set on the device, the below methods will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device. Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
+/// Reads and writes keychain elements that are stored on the Secure Enclave (available on iOS 8.0 and later and macOS 10.11 and later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. Accessing these keychain elements will require the user to confirm their presence via Touch ID or passcode entry. If no passcode is set on the device, the below methods will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device. Use the userPrompt methods to display custom text to the user in Apple's Touch ID and passcode entry UI.
 /// @version Available on iOS 8 or later, and macOS 10.11 or later.
 @interface VALSecureEnclaveValet : VALValet
 
-/// @return YES if Secure Enclave storage is supported on the current iOS version (8.0 and later).
+/// @return YES if Secure Enclave storage is supported on the current iOS or macOS version (iOS 8.0 and macOS 10.11 and later).
 + (BOOL)supportsSecureEnclaveKeychainItems;
 
 /// Creates a Valet that reads/writes Secure Enclave keychain elements and the specified access control.

--- a/Valet/VALSecureEnclaveValet_Protected.h
+++ b/Valet/VALSecureEnclaveValet_Protected.h
@@ -1,0 +1,18 @@
+//
+//  VALSecureEnclaveValet_Protected.h
+//  Valet
+//
+//  Created by Dan Federman on 1/23/17.
+//  Copyright © 2017 Square, Inc. All rights reserved.
+//
+
+#import <Valet/VALValet.h>
+
+
+@interface VALSecureEnclaveValet ()
+
+- (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt userCancelled:(nullable inout BOOL *)userCancelled options:(nullable NSDictionary *)options;
+
+- (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt userCancelled:(nullable inout BOOL *)userCancelled options:(nullable NSDictionary *)options;
+
+@end

--- a/Valet/VALSinglePromptSecureEnclaveValet.h
+++ b/Valet/VALSinglePromptSecureEnclaveValet.h
@@ -1,0 +1,20 @@
+//
+//  VALSinglePromptSecureEnclaveValet.h
+//  Valet
+//
+//  Created by Dan Federman on 1/23/17.
+//  Copyright © 2017 Square, Inc. All rights reserved.
+//
+
+#import <Valet/VALSecureEnclaveValet.h>
+
+
+/// Reads and writes keychain elements that are stored on the Secure Enclave (available on iOS 8.0 and later and macOS 10.11 and later) using accessibility attribute VALAccessibilityWhenPasscodeSetThisDeviceOnly. The first access of these keychain elements will require the user to confirm their presence via Touch ID or passcode entry.
+/// @see VALSecureEnclaveValet
+/// @version Available on iOS 8 or later, and macOS 10.11 or later.
+@interface VALSinglePromptSecureEnclaveValet : VALSecureEnclaveValet
+
+/// Forces a prompt for Touch ID or passcode entry on the next data retrieval from the Secure Enclave.
+- (void)requirePromptOnNextAccess;
+
+@end

--- a/Valet/VALSinglePromptSecureEnclaveValet.m
+++ b/Valet/VALSinglePromptSecureEnclaveValet.m
@@ -1,0 +1,139 @@
+//
+//  VALSinglePromptSecureEnclaveValet.m
+//  Valet
+//
+//  Created by Dan Federman on 1/23/17.
+//  Copyright © 2017 Square, Inc. All rights reserved.
+//
+
+#import "VALSinglePromptSecureEnclaveValet.h"
+#import "VALSecureEnclaveValet_Protected.h"
+#import "VALValet_Protected.h"
+
+#import "ValetDefines.h"
+
+
+#if VAL_SECURE_ENCLAVE_SDK_AVAILABLE
+#import <LocalAuthentication/LocalAuthentication.h>
+
+
+@interface VALSinglePromptSecureEnclaveValet ()
+
+@property (nonnull, strong, readwrite) LAContext *context;
+
+@end
+
+
+@implementation VALSinglePromptSecureEnclaveValet
+
+#pragma mark - Initialization
+
+- (nullable instancetype)initWithIdentifier:(nonnull NSString *)identifier accessControl:(VALAccessControl)accessControl;
+{
+    self = [super initWithIdentifier:identifier accessControl:accessControl];
+    
+    if (self != nil) {
+        _context = [LAContext new];
+    }
+    
+    return self;
+}
+
+- (nullable instancetype)initWithSharedAccessGroupIdentifier:(nonnull NSString *)sharedAccessGroupIdentifier accessControl:(VALAccessControl)accessControl;
+{
+    self = [super initWithSharedAccessGroupIdentifier:sharedAccessGroupIdentifier accessControl:accessControl];
+    
+    if (self != nil) {
+        _context = [LAContext new];
+    }
+    
+    return self;
+}
+
+#pragma mark - VALValet
+
+- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key;
+{
+    return [self setObject:value forKey:key options:[self _contextOptions]];
+}
+
+- (nullable NSData *)objectForKey:(nonnull NSString *)key;
+{
+    return [self objectForKey:key options:[self _contextOptions] status:nil];
+}
+
+- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key;
+{
+    return [self setString:string forKey:key options:[self _contextOptions]];
+}
+
+- (nullable NSString *)stringForKey:(nonnull NSString *)key;
+{
+    return [self stringForKey:key options:[self _contextOptions] status:nil];
+}
+
+- (BOOL)containsObjectForKey:(NSString *)key;
+{
+    OSStatus const status = [self containsObjectForKey:key options:[self _contextOptions]];
+    BOOL const keyAlreadyInKeychain = (status == errSecInteractionNotAllowed || status == errSecSuccess);
+    return keyAlreadyInKeychain;
+}
+
+- (BOOL)removeObjectForKey:(nonnull NSString *)key;
+{
+    return [self removeObjectForKey:key options:[self _contextOptions]];
+}
+
+#pragma mark - VALSecureEnclaveValet
+
+- (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt;
+{
+    return [self objectForKey:key userPrompt:userPrompt userCancelled:nil options:[self _contextOptions]];
+}
+
+- (nullable NSData *)objectForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt userCancelled:(nullable inout BOOL *)userCancelled;
+{
+    return [self objectForKey:key userPrompt:userPrompt userCancelled:userCancelled options:[self _contextOptions]];
+}
+
+- (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt;
+{
+    return [self stringForKey:key userPrompt:userPrompt userCancelled:nil options:[self _contextOptions]];
+}
+
+- (nullable NSString *)stringForKey:(nonnull NSString *)key userPrompt:(nullable NSString *)userPrompt userCancelled:(nullable inout BOOL *)userCancelled;
+{
+    return [self stringForKey:key userPrompt:userPrompt userCancelled:userCancelled options:[self _contextOptions]];
+}
+
+#pragma mark - Public Methods
+
+- (void)requirePromptOnNextAccess;
+{
+    VALAtomicSecItemLock(^{
+        [self.context invalidate];
+        self.context = [LAContext new];
+    });
+}
+
+#pragma mark - Private Methods
+
+- (nonnull NSDictionary *)_contextOptions;
+{
+    return @{ (__bridge id)kSecUseAuthenticationContext : self.context };
+}
+
+@end
+
+#else // Below this line we're in !VAL_SECURE_ENCLAVE_SDK_AVAILABLE, meaning none of our API is actually usable. Return NO or nil everywhere.
+
+@implementation VALSinglePromptSecureEnclaveValet
+
+- (void)requirePromptOnNextAccess;
+{
+    VALCheckCondition(NO, , @"VALSinglePromptSecureEnclaveValet unsupported on this SDK");
+}
+
+@end
+
+#endif // VAL_SECURE_ENCLAVE_SDK_AVAILABLE

--- a/Valet/VALValet_Protected.h
+++ b/Valet/VALValet_Protected.h
@@ -22,6 +22,7 @@
 
 
 extern NSString * __nonnull VALStringForAccessibility(VALAccessibility accessibility);
+extern void VALAtomicSecItemLock(__nonnull dispatch_block_t block);
 
 
 @interface VALValet ()

--- a/Valet/Valet.h
+++ b/Valet/Valet.h
@@ -21,3 +21,4 @@
 #import <Valet/VALValet.h>
 #import <Valet/VALSecureEnclaveValet.h>
 #import <Valet/VALSynchronizableValet.h>
+#import <Valet/VALSinglePromptSecureEnclaveValet.h>

--- a/ValetTouchIDTest/Base.lproj/ValetSecureElementTestLaunchScreen.xib
+++ b/ValetTouchIDTest/Base.lproj/ValetSecureElementTestLaunchScreen.xib
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -15,17 +19,17 @@
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Licensed to Square, Inc. under one or more contributor license agreements." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="440" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ValetSecureElementTest" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
                     <rect key="frame" x="20" y="140" width="441" height="43"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
                 <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>

--- a/ValetTouchIDTest/Base.lproj/ValetSecureElementTestMain.storyboard
+++ b/ValetTouchIDTest/Base.lproj/ValetSecureElementTestMain.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Valet TouchID Test View Controller-->
@@ -15,75 +19,81 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <userGuides>
+                            <userLayoutGuide location="333" affinity="minY"/>
+                        </userGuides>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qA9-Wb-ZwB">
-                                <rect key="frame" x="240" y="40" width="121" height="30"/>
-                                <state key="normal" title="Set / Update Item">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="setOrUpdateItem:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="b2V-qJ-PaJ"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QAP-hZ-KqD">
-                                <rect key="frame" x="256" y="116" width="89" height="30"/>
+                                <rect key="frame" x="143" y="112" width="89" height="30"/>
                                 <state key="normal" title="Remove Item">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="removeItem:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Aqe-hG-4W2"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQk-O3-Rdt">
-                                <rect key="frame" x="271" y="78" width="59" height="30"/>
+                                <rect key="frame" x="158" y="74" width="59" height="30"/>
                                 <state key="normal" title="Get Item">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="getItem:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="acb-zS-FOp"/>
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2ld-mY-LH3">
-                                <rect key="frame" x="20" y="200" width="560" height="400"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <rect key="frame" x="20" y="234" width="335" height="366"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IBe-vA-Xz7" userLabel="Contains Item">
-                                <rect key="frame" x="249" y="154" width="102" height="30"/>
+                                <rect key="frame" x="136.5" y="150" width="102" height="30"/>
                                 <state key="normal" title="Contains Item?">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="containsItem:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="mzu-8F-5tK"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qA9-Wb-ZwB">
+                                <rect key="frame" x="127" y="36" width="121" height="30"/>
+                                <state key="normal" title="Set / Update Item">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="setOrUpdateItem:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="b2V-qJ-PaJ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TrM-oi-UIh" userLabel="Contains Item">
+                                <rect key="frame" x="134" y="188" width="107" height="30"/>
+                                <state key="normal" title="Require Prompt">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="requirePrompt:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="elD-gZ-8qG"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="QAP-hZ-KqD" firstAttribute="bottom" secondItem="IBe-vA-Xz7" secondAttribute="bottom" constant="8" id="0qz-yF-sVW"/>
-                            <constraint firstItem="IBe-vA-Xz7" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="1JS-dh-03i"/>
-                            <constraint firstItem="qA9-Wb-ZwB" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="20" id="5HK-3b-R62"/>
-                            <constraint firstItem="ZQk-O3-Rdt" firstAttribute="top" secondItem="qA9-Wb-ZwB" secondAttribute="bottom" constant="8" id="Eev-yE-RFc"/>
-                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="2ld-mY-LH3" secondAttribute="bottom" id="PuW-TG-ua5"/>
-                            <constraint firstItem="2ld-mY-LH3" firstAttribute="top" secondItem="IBe-vA-Xz7" secondAttribute="bottom" constant="16" id="S2E-TD-rKz"/>
-                            <constraint firstAttribute="centerX" secondItem="qA9-Wb-ZwB" secondAttribute="centerX" id="Sbp-WM-Dnp"/>
-                            <constraint firstItem="2ld-mY-LH3" firstAttribute="top" secondItem="QAP-hZ-KqD" secondAttribute="bottom" constant="16" id="T5y-Ub-0ZH"/>
-                            <constraint firstItem="ZQk-O3-Rdt" firstAttribute="centerX" secondItem="QAP-hZ-KqD" secondAttribute="centerX" id="VVo-AP-RdJ"/>
-                            <constraint firstItem="QAP-hZ-KqD" firstAttribute="top" secondItem="ZQk-O3-Rdt" secondAttribute="bottom" constant="8" id="gj0-GH-t1C"/>
-                            <constraint firstItem="2ld-mY-LH3" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="qBp-Fw-ZPV"/>
-                            <constraint firstItem="ZQk-O3-Rdt" firstAttribute="centerX" secondItem="qA9-Wb-ZwB" secondAttribute="centerX" id="rVy-u4-o0t"/>
-                            <constraint firstItem="IBe-vA-Xz7" firstAttribute="top" secondItem="QAP-hZ-KqD" secondAttribute="bottom" constant="8" id="uOt-B5-PdV"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="2ld-mY-LH3" secondAttribute="trailing" id="wwD-yW-UdN"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="2ld-mY-LH3" secondAttribute="trailing" constant="4" id="3VY-Kj-j1E"/>
+                            <constraint firstItem="TrM-oi-UIh" firstAttribute="top" secondItem="IBe-vA-Xz7" secondAttribute="bottom" constant="8" id="6Hi-i3-5ST"/>
+                            <constraint firstItem="2ld-mY-LH3" firstAttribute="top" secondItem="TrM-oi-UIh" secondAttribute="bottom" constant="16" id="7HU-uU-rUj"/>
+                            <constraint firstItem="ZQk-O3-Rdt" firstAttribute="centerX" secondItem="QAP-hZ-KqD" secondAttribute="centerX" id="F6H-wj-y99"/>
+                            <constraint firstItem="TrM-oi-UIh" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="I6y-5v-7M8"/>
+                            <constraint firstItem="QAP-hZ-KqD" firstAttribute="top" secondItem="ZQk-O3-Rdt" secondAttribute="bottom" constant="8" symbolic="YES" id="NsI-jm-LCG"/>
+                            <constraint firstItem="IBe-vA-Xz7" firstAttribute="top" secondItem="QAP-hZ-KqD" secondAttribute="bottom" constant="8" symbolic="YES" id="Nvw-rJ-hhP"/>
+                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="2ld-mY-LH3" secondAttribute="bottom" constant="67" id="bgQ-tP-hTr"/>
+                            <constraint firstItem="IBe-vA-Xz7" firstAttribute="centerX" secondItem="2ld-mY-LH3" secondAttribute="centerX" id="fJD-vW-RTr"/>
+                            <constraint firstItem="qA9-Wb-ZwB" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="gcw-tf-BOc"/>
+                            <constraint firstItem="2ld-mY-LH3" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="4" id="hux-k4-H1T"/>
+                            <constraint firstItem="qA9-Wb-ZwB" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="16" id="tAs-qz-dgW"/>
+                            <constraint firstItem="ZQk-O3-Rdt" firstAttribute="top" secondItem="qA9-Wb-ZwB" secondAttribute="bottom" constant="8" symbolic="YES" id="veq-n5-XaN"/>
+                            <constraint firstItem="QAP-hZ-KqD" firstAttribute="centerX" secondItem="IBe-vA-Xz7" secondAttribute="centerX" id="w0w-Jr-4iW"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="T5y-Ub-0ZH"/>
-                                <exclude reference="0qz-yF-sVW"/>
-                            </mask>
-                        </variation>
                     </view>
                     <connections>
                         <outlet property="textView" destination="2ld-mY-LH3" id="9nm-d5-K77"/>

--- a/ValetTouchIDTest/ValetTouchIDTestViewController.swift
+++ b/ValetTouchIDTest/ValetTouchIDTestViewController.swift
@@ -26,7 +26,7 @@ final class ValetTouchIDTestViewController : UIViewController
     // MARK: Properties
 
     @IBOutlet var textView : UITextView?
-    let secureEnclaveValet : VALSecureEnclaveValet
+    var singlePromptSecureEnclaveValet : VALSinglePromptSecureEnclaveValet
     let username = "CustomerPresentProof"
 
 
@@ -34,8 +34,8 @@ final class ValetTouchIDTestViewController : UIViewController
 
     required init?(coder aDecoder: NSCoder)
     {
-        if let valet = VALSecureEnclaveValet(identifier: "UserPresence", accessControl: VALAccessControl.userPresence) {
-            self.secureEnclaveValet = valet
+        if let valet = VALSinglePromptSecureEnclaveValet(identifier: "UserPresence", accessControl: VALAccessControl.userPresence) {
+            self.singlePromptSecureEnclaveValet = valet
         } else {
             return nil;
         }
@@ -50,7 +50,7 @@ final class ValetTouchIDTestViewController : UIViewController
     @IBAction func setOrUpdateItem(sender: UIResponder)
     {
         let stringToSet = "I am here! " + NSUUID().uuidString
-        let setOrUpdatedItem = secureEnclaveValet.setString(stringToSet, forKey: username)
+        let setOrUpdatedItem = singlePromptSecureEnclaveValet.setString(stringToSet, forKey: username)
         updateTextView(messageComponents: #function, (setOrUpdatedItem ? "Success" : "Failure"))
     }
 
@@ -58,7 +58,7 @@ final class ValetTouchIDTestViewController : UIViewController
     @IBAction func getItem(sender: UIResponder)
     {
         var userCancelled: ObjCBool = false
-        let password = secureEnclaveValet.string(forKey: username, userPrompt: "Use TouchID to retrieve password", userCancelled:&userCancelled)
+        let password = singlePromptSecureEnclaveValet.string(forKey: username, userPrompt: "Use TouchID to retrieve password", userCancelled:&userCancelled)
 
         var resultString: String
         if (userCancelled.boolValue) {
@@ -75,18 +75,24 @@ final class ValetTouchIDTestViewController : UIViewController
     @objc(removeItem:)
     @IBAction func removeItem(sender: UIResponder)
     {
-        let removedItem = secureEnclaveValet.removeObject(forKey: username)
+        let removedItem = singlePromptSecureEnclaveValet.removeObject(forKey: username)
         updateTextView(messageComponents: #function, (removedItem ? "Success" : "Failure"))
     }
 
     @objc(containsItem:)
     @IBAction func containsItem(sender: UIResponder)
     {
-        let containsItem = secureEnclaveValet.containsObject(forKey: username)
+        let containsItem = singlePromptSecureEnclaveValet.containsObject(forKey: username)
         updateTextView(messageComponents: #function, (containsItem ? "YES" : "NO"))
     }
 
-
+    @objc(requirePrompt:)
+    @IBAction func requirePrompt(sender: UIResponder)
+    {
+        singlePromptSecureEnclaveValet.requirePromptOnNextAccess()
+        updateTextView(messageComponents: #function)
+    }
+    
     // MARK: Private
 
     private func updateTextView(messageComponents: String...)


### PR DESCRIPTION
Fixes #104.

Paired with @EricMuller22 on this. @juantrias, please review

Outstanding work:
- [x] Write a toggle into `ValetTouchIDTest` that allows for testing `VALSinglePromptSecureEnclaveValet`
- [x] Update the README to include usage instructions for `VALSinglePromptSecureEnclaveValet`
- [ ] Enable `allKeys` and `removeAllObjects` methods on `VALSinglePromptSecureEnclaveValet` (we will likely punt this to an Issue)

@juantrias, it's worth noting we did not find a workaround for the following issue:
1) Authenticate `VALSinglePromptSecureEnclaveValet` with `TouchIDCurrentFingerprintSet`
2) Change fingerprints
-> Values still show up in existing authenticated `VALSinglePromptSecureEnclaveValet` instance.

I think the best way to get around this is to invalidate the context (call `requirePromptOnNextAccess`) when the app enters the background (e.g. fires `UIApplicationDidEnterBackgroundNotification`). We could not determine a way to detect that fingerprints changed... so it's likely best to invalidate the context whenever the fingerprints _could_ change, i.e. when the app is no longer in the foreground. Not ideal, but neither is the Keychain API ;)