### PR TITLE
FIX [VALSinglePromptSecureEnclaveValet containsObjectForKey] on TouchID fingerprints changes 

### DIFF
--- a/Valet/VALSinglePromptSecureEnclaveValet.m
+++ b/Valet/VALSinglePromptSecureEnclaveValet.m
@@ -52,29 +52,14 @@
 
 #pragma mark - VALValet
 
-- (BOOL)setObject:(nonnull NSData *)value forKey:(nonnull NSString *)key;
-{
-    return [self setObject:value forKey:key options:[self _contextOptions]];
-}
-
 - (nullable NSData *)objectForKey:(nonnull NSString *)key;
 {
     return [self objectForKey:key options:[self _contextOptions] status:nil];
 }
 
-- (BOOL)setString:(nonnull NSString *)string forKey:(nonnull NSString *)key;
-{
-    return [self setString:string forKey:key options:[self _contextOptions]];
-}
-
 - (nullable NSString *)stringForKey:(nonnull NSString *)key;
 {
     return [self stringForKey:key options:[self _contextOptions] status:nil];
-}
-
-- (BOOL)removeObjectForKey:(nonnull NSString *)key;
-{
-    return [self removeObjectForKey:key options:[self _contextOptions]];
 }
 
 #pragma mark - VALSecureEnclaveValet

--- a/Valet/VALSinglePromptSecureEnclaveValet.m
+++ b/Valet/VALSinglePromptSecureEnclaveValet.m
@@ -72,13 +72,6 @@
     return [self stringForKey:key options:[self _contextOptions] status:nil];
 }
 
-- (BOOL)containsObjectForKey:(NSString *)key;
-{
-    OSStatus const status = [self containsObjectForKey:key options:[self _contextOptions]];
-    BOOL const keyAlreadyInKeychain = (status == errSecInteractionNotAllowed || status == errSecSuccess);
-    return keyAlreadyInKeychain;
-}
-
 - (BOOL)removeObjectForKey:(nonnull NSString *)key;
 {
     return [self removeObjectForKey:key options:[self _contextOptions]];


### PR DESCRIPTION
`[VALSinglePromptSecureEnclaveValet containsObjectForKey]` is returning `YES` after the key has been removed from the Keychain due to TouchID fingerprints changes, after adding or removing a fingerprint. The reason is that the `LAContext` instance kept by `VALSinglePromptSecureEnclaveValet` has the key cached. So, for `containsObjectForKey`, we need to query the Keychain without using this instance, as in regular `VALSecureEnclaveValet`.

Additionally, although this does not affect the functionality, we only need to pass the `LAContext` instance when reading keys from the Keychain, not when adding or removing keys