### PR TITLE
Explicitly mention the 'use_frameworks!' requirement when pulling in Valet via Cocoapods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ on iOS:
 
 ```
 platform :ios, '9.0'
+use_frameworks!
 pod 'Valet'
 ```
 
@@ -25,6 +26,7 @@ on macOS:
 
 ```
 platform :osx, '10.11'
+use_frameworks!
 pod 'Valet'
 ```
 


### PR DESCRIPTION
Now that we're written in Swift, not having `use_frameworks!` in the Podfile would cause our adoptees' builds to fail.