### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 .DS_Store
 build/
+.build/
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Valet",
+    products: [
+        .library(name: "Valet", targets: ["Valet"]),
+    ],
+    targets: [
+        .target(name: "Valet", path: "Sources"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ github "Square/Valet"
 
 Run `carthage` to build the framework and drag the built `Valet.framework` into your Xcode project.
 
+### Swift Package Manager
+
+Install with [Swift Package Manager](https://github.com/apple/swift-package-manager) by adding the following to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Square/Valet", from: "3.0.0"),
+],
+```
+
 ### Submodules
 
 Or manually checkout the submodule with `git submodule add git@github.com:Square/Valet.git`, drag Valet.xcodeproj to your project, and add Valet as a build dependency.

--- a/Sources/SecureEnclave.swift
+++ b/Sources/SecureEnclave.swift
@@ -21,6 +21,7 @@
 import Foundation
 
 
+@available(macOS 10.11, *)
 public final class SecureEnclave {
     
     // MARK: Result
@@ -169,5 +170,5 @@ public final class SecureEnclave {
                 return .itemNotFound
             }
         }
-    }    
+    }
 }

--- a/Sources/SecureEnclaveAccessControl.swift
+++ b/Sources/SecureEnclaveAccessControl.swift
@@ -89,7 +89,12 @@ public enum SecureEnclaveAccessControl: Int, CustomStringConvertible, Equatable 
                 return .userPresence
             }
         case .devicePasscode:
-            return .devicePasscode
+            if #available(macOS 10.11, *) {
+                return .devicePasscode
+            } else {
+                ErrorHandler.assertionFailure(".devicePasscode requires macOS 10.11.")
+                return .userPresence
+            }
         }
     }
     

--- a/Sources/SecureEnclaveValet.swift
+++ b/Sources/SecureEnclaveValet.swift
@@ -22,6 +22,7 @@ import Foundation
 
 
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. Accessing these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
+@available(macOS 10.11, *)
 @objc(VALSecureEnclaveValet)
 public final class SecureEnclaveValet: NSObject {
     
@@ -223,6 +224,7 @@ public final class SecureEnclaveValet: NSObject {
 // MARK: - Objective-C Compatibility
 
 
+@available(macOS 10.11, *)
 extension SecureEnclaveValet {
     
     // MARK: Public Class Methods

--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -23,6 +23,7 @@ import Foundation
 
 
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. The first access of these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SinglePromptSecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
+@available(macOS 10.11, *)
 @objc(VALSinglePromptSecureEnclaveValet)
 public final class SinglePromptSecureEnclaveValet: NSObject {
     
@@ -264,6 +265,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
 // MARK: - Objective-C Compatibility
 
 
+@available(macOS 10.11, *)
 extension SinglePromptSecureEnclaveValet {
     
     // MARK: Public Class Methods


### PR DESCRIPTION
This was supposedly done with 3.0 according to #89, but I couldn't find any trace of it.

Fixes #89 
Ping @dfed 

If anyone wants to test this about before we merge, you can use the following dependency:

```swift
.package(url: "https://github.com/LinusU/Valet", .branch("swiftpm")),
```