### PR TITLE
Remove SinglePromptSecureEnclaveValet from tvOS target

### DIFF
--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -23,7 +23,7 @@ import Foundation
 
 
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. The first access of these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SinglePromptSecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
-@available(tvOS 10.0, macOS 10.11, *)
+@available(macOS 10.11, *)
 @objc(VALSinglePromptSecureEnclaveValet)
 public final class SinglePromptSecureEnclaveValet: NSObject {
     
@@ -265,7 +265,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
 // MARK: - Objective-C Compatibility
 
 
-@available(tvOS 10.0, macOS 10.11, *)
+@available(macOS 10.11, *)
 extension SinglePromptSecureEnclaveValet {
     
     // MARK: Public Class Methods

--- a/Tests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/SinglePromptSecureEnclaveTests.swift
@@ -23,11 +23,10 @@ import Foundation
 import XCTest
 
 
-@available(tvOS 10.0, *)
 class SinglePromptSecureEnclaveTests: XCTestCase
 {
     static let identifier = Identifier(nonEmpty: "valet_testing")!
-    var valet: SinglePromptSecureEnclaveValet!
+    let valet = SinglePromptSecureEnclaveValet.valet(with: SinglePromptSecureEnclaveTests.identifier, accessControl: .userPresence)
     let key = "key"
     let passcode = "topsecret"
 
@@ -39,10 +38,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
             // Nothing to do here.
         }
 
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-        valet = SinglePromptSecureEnclaveValet.valet(with: SinglePromptSecureEnclaveTests.identifier, accessControl: .userPresence)
         valet.removeObject(forKey: key)
     }
     
@@ -50,9 +45,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_haveEqualPointers()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
         let equivalentValet = SinglePromptSecureEnclaveValet.valet(with: valet.identifier, accessControl: valet.accessControl)
         XCTAssertTrue(valet == equivalentValet)
         XCTAssertTrue(valet === equivalentValet)
@@ -60,10 +52,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_canAccessSameData()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -76,10 +64,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_SinglePromptSecureEnclaveValetsWithDifferingAccessControl_canNotAccessSameData()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -95,10 +79,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_allKeys()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -116,10 +96,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
     
     func test_allKeys_doesNotReflectValetImplementationDetails() {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         // Under the hood, Valet inserts a canary when calling `canAccessKeychain()` - this should not appear in `allKeys()`.
         _ = valet.canAccessKeychain()
         XCTAssertEqual(valet.allKeys(userPrompt: "it me"), Set())
@@ -129,10 +105,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_canAccessKeychain()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -146,10 +118,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
     
     func test_canAccessKeychain_sharedAccessGroup() {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -159,8 +127,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
             sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-iOS-Test-Host-App")!
         #elseif os(OSX)
             sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
-        #elseif os(tvOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-tvOS-Test-Host-App")!
         #else
             XCTFail()
         #endif
@@ -177,10 +143,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_migrateObjectsMatchingQuery_failsForBadQuery()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -194,10 +156,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclave()
     {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -234,10 +192,6 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
     
     func test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCalls() {
-        guard AvailabilityEnforcer.canRunTest else {
-            return
-        }
-
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -262,16 +216,4 @@ class SinglePromptSecureEnclaveTests: XCTestCase
             XCTAssertEqual(otherValet.string(forKey: key), value)
         }
     }
-}
-
-private class AvailabilityEnforcer {
-    static var canRunTest: Bool = {
-        if #available(tvOS 10.0, *) {
-            return true
-        } else {
-            // XCTest is really dumb. It will run SinglePromptSecureEnclaveTests – which is marked as available starting on tvOS 10 – when running tests against tvOS 9.
-            // To avoid crashing when instantiating this class or when running tests on tvOS 9, we manually check for availability here.
-            return false
-        }
-    }()
 }

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '3.1.0'
+  s.version  = '3.1.1'
   s.license  = 'Apache License, Version 2.0'
-  s.summary  = 'Valet lets you securely store data in the iOS or OS X Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
+  s.summary  = 'Securely store data in the iOS, tvOS, or macOS Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
@@ -13,13 +13,15 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.macos.deployment_target = '10.11'
 
+  s.tvos.exclude_files = 'Sources/SinglePromptSecureEnclaveValet.swift'
+
   s.test_spec 'Tests' do |test_spec|
     test_spec.ios.requires_app_host = true
     test_spec.ios.source_files = 'Tests/**/*.{h,m,swift}'
     test_spec.ios.exclude_files = 'Tests/MacTests.swift'
     test_spec.tvos.requires_app_host = true
     test_spec.tvos.source_files = 'Tests/**/*.{h,m,swift}'
-    test_spec.tvos.exclude_files = ['Tests/MacTests.swift', 'Tests/*BackwardsCompatibilityTests.swift']
+    test_spec.tvos.exclude_files = ['Tests/MacTests.swift', 'Tests/*BackwardsCompatibilityTests.swift', 'Tests/SinglePromptSecureEnclaveTests.swift']
     test_spec.macos.source_files = 'Tests/**/*.{h,m,swift}'
     test_spec.pod_target_xcconfig = {
       'SWIFT_OBJC_BRIDGING_HEADER' => '${PODS_TARGET_SRCROOT}/Tests/ValetTests-Bridging-Header.h',

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		16C3B089204B1E1500B4D0B4 /* MigrationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE91F71B6D300E8552D /* MigrationResult.swift */; };
 		16C3B08A204B1E1500B4D0B4 /* SecureEnclave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE01F71B6D200E8552D /* SecureEnclave.swift */; };
 		16C3B08B204B1E1500B4D0B4 /* SecureEnclaveAccessControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE81F71B6D200E8552D /* SecureEnclaveAccessControl.swift */; };
-		16C3B08C204B1E1500B4D0B4 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE41F71B6D200E8552D /* SinglePromptSecureEnclaveValet.swift */; };
 		16C3B08D204B1E1500B4D0B4 /* SecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE31F71B6D200E8552D /* SecureEnclaveValet.swift */; };
 		16C3B08E204B1E1500B4D0B4 /* Valet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BE61F71B6D200E8552D /* Valet.swift */; };
 		16C3B08F204B1E1500B4D0B4 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BDD1F71B6C400E8552D /* Configuration.swift */; };
@@ -40,7 +39,6 @@
 		16C3B0A3204B1EA700B4D0B4 /* Valet.h in Headers */ = {isa = PBXBuildFile; fileRef = 16EB523D1F71BC6B00363869 /* Valet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16C3B0A5204B203100B4D0B4 /* SecItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BED1F71B72C00E8552D /* SecItemTests.swift */; };
 		16C3B0A6204B203100B4D0B4 /* SecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BEE1F71B72C00E8552D /* SecureEnclaveTests.swift */; };
-		16C3B0A7204B203100B4D0B4 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11C5561F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift */; };
 		16C3B0A8204B203100B4D0B4 /* SynchronizableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BEF1F71B72C00E8552D /* SynchronizableTests.swift */; };
 		16C3B0A9204B207F00B4D0B4 /* ValetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E04BF31F71B72C00E8552D /* ValetTests.swift */; };
 		16C3B0AB204B20E200B4D0B4 /* SynchronizableBackwardsCompatibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C3B0AA204B20E200B4D0B4 /* SynchronizableBackwardsCompatibilityTests.swift */; };
@@ -969,7 +967,6 @@
 				16C3B089204B1E1500B4D0B4 /* MigrationResult.swift in Sources */,
 				16C3B08A204B1E1500B4D0B4 /* SecureEnclave.swift in Sources */,
 				16C3B08B204B1E1500B4D0B4 /* SecureEnclaveAccessControl.swift in Sources */,
-				16C3B08C204B1E1500B4D0B4 /* SinglePromptSecureEnclaveValet.swift in Sources */,
 				16C3B08D204B1E1500B4D0B4 /* SecureEnclaveValet.swift in Sources */,
 				16C3B08E204B1E1500B4D0B4 /* Valet.swift in Sources */,
 				16C3B08F204B1E1500B4D0B4 /* Configuration.swift in Sources */,
@@ -986,7 +983,6 @@
 				16C3B0A9204B207F00B4D0B4 /* ValetTests.swift in Sources */,
 				16C3B0A5204B203100B4D0B4 /* SecItemTests.swift in Sources */,
 				16C3B0A6204B203100B4D0B4 /* SecureEnclaveTests.swift in Sources */,
-				16C3B0A7204B203100B4D0B4 /* SinglePromptSecureEnclaveTests.swift in Sources */,
 				16C3B0A8204B203100B4D0B4 /* SynchronizableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
It turns out that `LocalAuthentication` isn't available on tvOS... despite Xcode showing me that it was 🙄. Building for tvOS device (rather than sim) failed due to our `import LocalAuthentication`.

This PR removes `SinglePromptSecureEnclaveValet` from the tvOS target entirely.