### PR TITLE
Run carthage build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: objective-c
 osx_image: xcode9
 before_script:
     - bundle install
+    - brew outdated carthage || brew upgrade carthage
 script:
     - xcodebuild -project Valet.xcodeproj -scheme "Valet iOS" -sdk iphonesimulator -destination "platform=iOS Simulator,OS=11.0,name=iPhone 7" -configuration Debug -PBXBuildsContinueAfterErrors=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet tvOS" -sdk appletvsimulator11.0 -destination "platform=tvOS Simulator,name=Apple TV" -configuration Debug -PBXBuildsContinueAfterErrors=0 build test
     - xcodebuild -project Valet.xcodeproj -scheme "Valet Mac" -sdk macosx10.13 -configuration Debug -destination "platform=OS X" -PBXBuildsContinueAfterErrors=0 build test
     - bundle exec pod lib lint --verbose --fail-fast
+    - carthage build --verbose --no-skip-current


### PR DESCRIPTION
Unfortunately, I didn't realize that `LocalAuthentication` wasn't supported on tvOS until _after_ I'd merged #126. What turned me onto the oversight was Carthage failing to build.

This PR makes it so that we run Carthage in CI, so that this kind of issue doesn't happen again.

Built on top of #132 