### PR TITLE
Create sharedAccessGroup Valet when requested

### DIFF
--- a/Sources/SecureEnclaveValet.swift
+++ b/Sources/SecureEnclaveValet.swift
@@ -212,10 +212,13 @@ public final class SecureEnclaveValet: NSObject {
     public func migrateObjects(from keychain: KeychainQueryConvertible, removeOnCompletion: Bool) -> MigrationResult {
         return migrateObjects(matching: keychain.keychainQuery, removeOnCompletion: removeOnCompletion)
     }
-    
+
+    // MARK: Internal Properties
+
+    internal let service: Service
+
     // MARK: Private Properties
     
-    private let service: Service
     private let lock = NSLock()
     private let keychainQuery: [String : AnyHashable]
 }

--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -242,10 +242,13 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     public func migrateObjects(from keychain: KeychainQueryConvertible, removeOnCompletion: Bool) -> MigrationResult {
         return migrateObjects(matching: keychain.keychainQuery, removeOnCompletion: removeOnCompletion)
     }
-    
+
+    // MARK: Internal Properties
+
+    internal let service: Service
+
     // MARK: Private Properties
-    
-    private let service: Service
+
     private let lock = NSLock()
     private let baseKeychainQuery: [String : AnyHashable]
     private var localAuthenticationContext = LAContext()

--- a/Sources/Valet.swift
+++ b/Sources/Valet.swift
@@ -69,14 +69,19 @@ public final class Valet: NSObject, KeychainQueryConvertible {
     // MARK: Private Class Functions
 
     /// - returns: a Valet with the given Identifier, Flavor (and a shared access group service if requested)
-    private class func findOrCreate(_ identifier: Identifier, configuration: Configuration, sharedAccessGroup: Bool=false) -> Valet {
-        let service : Service = sharedAccessGroup ? .sharedAccessGroup(identifier, configuration) : .standard(identifier, configuration)
+    private class func findOrCreate(_ identifier: Identifier, configuration: Configuration, sharedAccessGroup: Bool = false) -> Valet {
+        let service: Service = sharedAccessGroup ? .sharedAccessGroup(identifier, configuration) : .standard(identifier, configuration)
         let key = service.description as NSString
         if let existingValet = identifierToValetMap.object(forKey: key) {
             return existingValet
 
         } else {
-            let valet = Valet(identifier: identifier, configuration: configuration)
+            let valet: Valet
+            if sharedAccessGroup {
+                valet = Valet(sharedAccess: identifier, configuration: configuration)
+            } else {
+                valet = Valet(identifier: identifier, configuration: configuration)
+            }
             identifierToValetMap.setObject(valet, forKey: key)
             return valet
         }

--- a/Tests/SecureEnclaveTests.swift
+++ b/Tests/SecureEnclaveTests.swift
@@ -40,7 +40,18 @@ class SecureEnclaveTests: XCTestCase
         
         valet.removeObject(forKey: key)
     }
-    
+
+    // MARK: Initialization
+
+    func test_init_createsCorrectValet() {
+        let identifier = ValetTests.identifier
+        let accessControl = SecureEnclaveAccessControl.userPresence
+        XCTAssertEqual(SecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service,
+                       Service.standard(identifier, .secureEnclave(accessControl)))
+        XCTAssertEqual(SecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service,
+                       Service.sharedAccessGroup(identifier, .secureEnclave(accessControl)))
+    }
+
     // MARK: Equality
     
     func test_secureEnclaveValetsWithEqualConfiguration_haveEqualPointers()

--- a/Tests/SecureEnclaveTests.swift
+++ b/Tests/SecureEnclaveTests.swift
@@ -43,13 +43,13 @@ class SecureEnclaveTests: XCTestCase
 
     // MARK: Initialization
 
-    func test_init_createsCorrectValet() {
+    func test_init_createsCorrectBackingService() {
         let identifier = ValetTests.identifier
-        let accessControl = SecureEnclaveAccessControl.userPresence
-        XCTAssertEqual(SecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service,
-                       Service.standard(identifier, .secureEnclave(accessControl)))
-        XCTAssertEqual(SecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service,
-                       Service.sharedAccessGroup(identifier, .secureEnclave(accessControl)))
+
+        SecureEnclaveAccessControl.allValues().forEach { accessControl in
+            let backingService = SecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service
+            XCTAssertEqual(backingService, Service.standard(identifier, .secureEnclave(accessControl)))
+        }
     }
 
     // MARK: Equality

--- a/Tests/SecureEnclaveTests.swift
+++ b/Tests/SecureEnclaveTests.swift
@@ -52,6 +52,15 @@ class SecureEnclaveTests: XCTestCase
         }
     }
 
+    func test_init_createsCorrectBackingService_sharedAccess() {
+        let identifier = ValetTests.identifier
+
+        SecureEnclaveAccessControl.allValues().forEach { accessControl in
+            let backingService = SecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service
+            XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .secureEnclave(accessControl)))
+        }
+    }
+
     // MARK: Equality
     
     func test_secureEnclaveValetsWithEqualConfiguration_haveEqualPointers()

--- a/Tests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/SinglePromptSecureEnclaveTests.swift
@@ -52,6 +52,15 @@ class SinglePromptSecureEnclaveTests: XCTestCase
         }
     }
 
+    func test_init_createsCorrectBackingService_sharedAccess() {
+        let identifier = ValetTests.identifier
+
+        SecureEnclaveAccessControl.allValues().forEach { accessControl in
+            let backingService = SinglePromptSecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service
+            XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .singlePromptSecureEnclave(accessControl)))
+        }
+    }
+
     // MARK: Equality
     
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_haveEqualPointers()

--- a/Tests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/SinglePromptSecureEnclaveTests.swift
@@ -43,13 +43,13 @@ class SinglePromptSecureEnclaveTests: XCTestCase
 
     // MARK: Initialization
 
-    func test_init_createsCorrectValet() {
+    func test_init_createsCorrectBackingService() {
         let identifier = ValetTests.identifier
-        let accessControl = SecureEnclaveAccessControl.userPresence
-        XCTAssertEqual(SinglePromptSecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service,
-                       Service.standard(identifier, .singlePromptSecureEnclave(accessControl)))
-        XCTAssertEqual(SinglePromptSecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service,
-                       Service.sharedAccessGroup(identifier, .singlePromptSecureEnclave(accessControl)))
+
+        SecureEnclaveAccessControl.allValues().forEach { accessControl in
+            let backingService = SinglePromptSecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service
+            XCTAssertEqual(backingService, Service.standard(identifier, .singlePromptSecureEnclave(accessControl)))
+        }
     }
 
     // MARK: Equality

--- a/Tests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/SinglePromptSecureEnclaveTests.swift
@@ -40,7 +40,18 @@ class SinglePromptSecureEnclaveTests: XCTestCase
 
         valet.removeObject(forKey: key)
     }
-    
+
+    // MARK: Initialization
+
+    func test_init_createsCorrectValet() {
+        let identifier = ValetTests.identifier
+        let accessControl = SecureEnclaveAccessControl.userPresence
+        XCTAssertEqual(SinglePromptSecureEnclaveValet.valet(with: identifier, accessControl: accessControl).service,
+                       Service.standard(identifier, .singlePromptSecureEnclave(accessControl)))
+        XCTAssertEqual(SinglePromptSecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service,
+                       Service.sharedAccessGroup(identifier, .singlePromptSecureEnclave(accessControl)))
+    }
+
     // MARK: Equality
     
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_haveEqualPointers()

--- a/Tests/ValetTests.swift
+++ b/Tests/ValetTests.swift
@@ -112,19 +112,40 @@ class ValetTests: XCTestCase
 
     // MARK: Initialization
 
-    func test_init_createsCorrectValet() {
+    func test_init_createsCorrectBackingService() {
         let identifier = ValetTests.identifier
-        let accessibility = Accessibility.whenUnlocked
-        XCTAssertEqual(Valet.valet(with: identifier, accessibility: accessibility).service,
-                       Service.standard(identifier, .valet(accessibility)))
-        XCTAssertEqual(Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service,
-                       Service.sharedAccessGroup(identifier, .valet(accessibility)))
 
-        let cloudAccessibility = CloudAccessibility.whenUnlocked
-        XCTAssertEqual(Valet.iCloudValet(with: identifier, accessibility: cloudAccessibility).service,
-                       Service.standard(identifier, .iCloud(cloudAccessibility)))
-        XCTAssertEqual(Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: cloudAccessibility).service,
-                       Service.sharedAccessGroup(identifier, .iCloud(cloudAccessibility)))
+        Accessibility.allValues().forEach { accessibility in
+            let backingService = Valet.valet(with: identifier, accessibility: accessibility).service
+            XCTAssertEqual(backingService, Service.standard(identifier, .valet(accessibility)))
+        }
+    }
+
+    func test_init_createsCorrectBackingService_sharedAccess() {
+        let identifier = ValetTests.identifier
+
+        Accessibility.allValues().forEach { accessibility in
+            let backingService = Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service
+            XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .valet(accessibility)))
+        }
+    }
+
+    func test_init_createsCorrectBackingService_cloud() {
+        let identifier = ValetTests.identifier
+
+        CloudAccessibility.allValues().forEach { accessibility in
+            let backingService = Valet.iCloudValet(with: identifier, accessibility: accessibility).service
+            XCTAssertEqual(backingService, Service.standard(identifier, .iCloud(accessibility)))
+        }
+    }
+
+    func test_init_createsCorrectBackingService_cloudSharedAccess() {
+        let identifier = ValetTests.identifier
+
+        CloudAccessibility.allValues().forEach { accessibility in
+            let backingService = Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: accessibility).service
+            XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .iCloud(accessibility)))
+        }
     }
 
     // MARK: Equality

--- a/Tests/ValetTests.swift
+++ b/Tests/ValetTests.swift
@@ -110,6 +110,23 @@ class ValetTests: XCTestCase
         XCTAssert(anotherFlavor.allKeys().isEmpty)
     }
 
+    // MARK: Initialization
+
+    func test_init_createsCorrectValet() {
+        let identifier = ValetTests.identifier
+        let accessibility = Accessibility.whenUnlocked
+        XCTAssertEqual(Valet.valet(with: identifier, accessibility: accessibility).service,
+                       Service.standard(identifier, .valet(accessibility)))
+        XCTAssertEqual(Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service,
+                       Service.sharedAccessGroup(identifier, .valet(accessibility)))
+
+        let cloudAccessibility = CloudAccessibility.whenUnlocked
+        XCTAssertEqual(Valet.iCloudValet(with: identifier, accessibility: cloudAccessibility).service,
+                       Service.standard(identifier, .iCloud(cloudAccessibility)))
+        XCTAssertEqual(Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: cloudAccessibility).service,
+                       Service.sharedAccessGroup(identifier, .iCloud(cloudAccessibility)))
+    }
+
     // MARK: Equality
 
     func test_valetsWithSameConfiguration_areEqual()

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -14,18 +14,4 @@ Pod::Spec.new do |s|
   s.macos.deployment_target = '10.11'
 
   s.tvos.exclude_files = 'Sources/SinglePromptSecureEnclaveValet.swift'
-
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.ios.requires_app_host = true
-    test_spec.ios.source_files = 'Tests/**/*.{h,m,swift}'
-    test_spec.ios.exclude_files = 'Tests/MacTests.swift'
-    test_spec.tvos.requires_app_host = true
-    test_spec.tvos.source_files = 'Tests/**/*.{h,m,swift}'
-    test_spec.tvos.exclude_files = ['Tests/MacTests.swift', 'Tests/*BackwardsCompatibilityTests.swift', 'Tests/SinglePromptSecureEnclaveTests.swift']
-    test_spec.macos.source_files = 'Tests/**/*.{h,m,swift}'
-    test_spec.pod_target_xcconfig = {
-      'SWIFT_OBJC_BRIDGING_HEADER' => '${PODS_TARGET_SRCROOT}/Tests/ValetTests-Bridging-Header.h',
-      'CLANG_WARN_UNGUARDED_AVAILABILITY' => 'YES'
-    }
-  end
 end

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '3.1.1'
+  s.version  = '3.1.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data in the iOS, tvOS, or macOS Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'


### PR DESCRIPTION
🔥 

Note to anyone who adopted v3.0-3.1.1:
- If you shipped an app with a `Valet.sharedAccessGroupValet` or `Valet.iCloudSharedAccessGroupValet`, you'll need to take steps to not lose secure data in your next release.

If you released an app with a `Valet.sharedAccessGroupValet`, you'll need to run `Valet.sharedAccessGroupValet(with: yourIdentifier, accessibility: yourAccessibility).migrateObjects(from: Valet.valet(with: yourIdentifier, accessibility: yourAccessibility), removeOnCompletion: true)` before accessing data in your `Valet.sharedAccessGroupValet`

If you released an app with a `Valet.iCloudSharedAccessGroupValet`, you'll need to run `Valet.iCloudSharedAccessGroupValet(with: yourIdentifier, accessibility: yourAccessibility).migrateObjects(from: Valet.iCloudValet(with: yourIdentifier, accessibility: yourAccessibility), removeOnCompletion: true)` before accessing data in your `Valet.iCloudSharedAccessGroupValet`