### PR TITLE
Swift Version

### DIFF
--- a/Valet.podspec
+++ b/Valet.podspec
@@ -6,12 +6,14 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
   s.source_files = 'Sources/**/*.{swift,h}'
   s.public_header_files = 'Sources/*.h'
   s.frameworks = 'Security'
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.macos.deployment_target = '10.11'
+  git@github.com:square/Valet.git
 
   s.tvos.exclude_files = 'Sources/SinglePromptSecureEnclaveValet.swift'
 end

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.swift_version = '4.0'
   s.source_files = 'Sources/**/*.{swift,h}'
   s.public_header_files = 'Sources/*.h'
   s.frameworks = 'Security'

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.macos.deployment_target = '10.11'
-  git@github.com:square/Valet.git
 
   s.tvos.exclude_files = 'Sources/SinglePromptSecureEnclaveValet.swift'
 end


### PR DESCRIPTION

This fixes https://github.com/square/Valet/issues/141 using the same strategy as https://github.com/jessesquires/JSQCoreDataKit/pull/99.
There is an error for non-swift projects that use the swift Valet.
It looks like this:
```
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.
```
Though the suggested workaround was to use Valet 2.0, I believe this fixes the underlying issue.
Reviewers @dfed