### PR TITLE
Add compatibility shim for flatMap rename

### DIFF
--- a/Sources/Internal/Keychain.swift
+++ b/Sources/Internal/Keychain.swift
@@ -202,17 +202,10 @@ internal final class Keychain {
                 return SecItem.DataResult.success(Set([singleKey]))
                 
             } else if let multipleMatches = collection as? [[String: AnyHashable]] {
-                #if swift(>=4.1)
                 return SecItem.DataResult.success(Set(multipleMatches.compactMap({ attributes in
                     let key = attributes[kSecAttrAccount as String] as? String
                     return key != canaryKey ? key : nil
                 })))
-                #else
-                return SecItem.DataResult.success(Set(multipleMatches.flatMap({ attributes in
-                    let key = attributes[kSecAttrAccount as String] as? String
-                    return key != canaryKey ? key : nil
-                })))
-                #endif
 
             } else {
                 return SecItem.DataResult.success(Set())

--- a/Sources/SwiftCompatibility.swift
+++ b/Sources/SwiftCompatibility.swift
@@ -1,0 +1,29 @@
+//
+//  SwiftCompatibility.swift
+//  Valet
+//
+//  Created by Gordon Fontenot on 7/26/18.
+//  Copyright © 2017 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if !swift(>=4.1)
+
+extension Sequence {
+    func compactMap<T>(_ transform: (Element) throws -> T?) rethrows -> [T] {
+        return try flatMap(transform)
+    }
+}
+
+#endif

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '3.1.4'
+  s.version  = '3.1.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data in the iOS, tvOS, or macOS Keychain without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		371150AD1E2962D8004A45D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 371150AB1E2962D8004A45D4 /* Main.storyboard */; };
 		371150AF1E2962D8004A45D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 371150AE1E2962D8004A45D4 /* Assets.xcassets */; };
 		371150B21E2962D8004A45D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 371150B01E2962D8004A45D4 /* LaunchScreen.storyboard */; };
+		38CF90CF210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38CF90CE210A25CF005B7FB2 /* SwiftCompatibility.swift */; };
+		38CF90D0210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38CF90CE210A25CF005B7FB2 /* SwiftCompatibility.swift */; };
+		38CF90D1210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38CF90CE210A25CF005B7FB2 /* SwiftCompatibility.swift */; };
 		AC11C5571F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11C5561F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift */; };
 		AC11C5581F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11C5561F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift */; };
 		AC89A3EC1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC89A3EB1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift */; };
@@ -249,6 +252,7 @@
 		371150B11E2962D8004A45D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		371150B31E2962D8004A45D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		37250B1D1E2DD55D008B4777 /* Valet iOS Test Host App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Valet iOS Test Host App.entitlements"; sourceTree = "<group>"; };
+		38CF90CE210A25CF005B7FB2 /* SwiftCompatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCompatibility.swift; sourceTree = "<group>"; };
 		AC11C5561F8197C200AE9842 /* SinglePromptSecureEnclaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglePromptSecureEnclaveTests.swift; sourceTree = "<group>"; };
 		AC89A3EA1CC82426009A7121 /* ValetTouchIDTest-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ValetTouchIDTest-Bridging-Header.h"; sourceTree = "<group>"; };
 		AC89A3EB1CC82426009A7121 /* ValetTouchIDTestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValetTouchIDTestAppDelegate.swift; sourceTree = "<group>"; };
@@ -387,6 +391,7 @@
 				16E04BE81F71B6D200E8552D /* SecureEnclaveAccessControl.swift */,
 				16E04BE41F71B6D200E8552D /* SinglePromptSecureEnclaveValet.swift */,
 				16E04BE31F71B6D200E8552D /* SecureEnclaveValet.swift */,
+				38CF90CE210A25CF005B7FB2 /* SwiftCompatibility.swift */,
 				16EB523D1F71BC6B00363869 /* Valet.h */,
 				16E04BE61F71B6D200E8552D /* Valet.swift */,
 				16E04BDA1F71B6AA00E8552D /* Internal */,
@@ -969,6 +974,7 @@
 				16C3B08B204B1E1500B4D0B4 /* SecureEnclaveAccessControl.swift in Sources */,
 				16C3B08D204B1E1500B4D0B4 /* SecureEnclaveValet.swift in Sources */,
 				16C3B08E204B1E1500B4D0B4 /* Valet.swift in Sources */,
+				38CF90D1210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */,
 				16C3B08F204B1E1500B4D0B4 /* Configuration.swift in Sources */,
 				16C3B090204B1E1500B4D0B4 /* Keychain.swift in Sources */,
 				16C3B091204B1E1500B4D0B4 /* SecItem.swift in Sources */,
@@ -1001,6 +1007,7 @@
 				16EB52531F71BDF400363869 /* Identifier.swift in Sources */,
 				16EB52661F71BDFF00363869 /* Configuration.swift in Sources */,
 				16EB52571F71BDF400363869 /* SecureEnclaveAccessControl.swift in Sources */,
+				38CF90CF210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */,
 				16EB52501F71BDF400363869 /* Accessibility.swift in Sources */,
 				16EB52681F71BDFF00363869 /* SecItem.swift in Sources */,
 				16EB52641F71BDF900363869 /* Valet.swift in Sources */,
@@ -1023,6 +1030,7 @@
 				16EB525D1F71BDF400363869 /* Identifier.swift in Sources */,
 				16EB526A1F71BDFF00363869 /* Configuration.swift in Sources */,
 				16EB52611F71BDF400363869 /* SecureEnclaveAccessControl.swift in Sources */,
+				38CF90D0210A25CF005B7FB2 /* SwiftCompatibility.swift in Sources */,
 				16EB525A1F71BDF400363869 /* Accessibility.swift in Sources */,
 				16EB526C1F71BDFF00363869 /* SecItem.swift in Sources */,
 				16EB52651F71BDFA00363869 /* Valet.swift in Sources */,


### PR DESCRIPTION
In Swift 4.1, the version of `flatMap` with the shape
`[T] -> (T -> U?) -> [U]` has been renamed to `compactMap`. By adding this
compatibility shim for Swift versions < 4.1, we can use the new spelling
without losing any backwards compatibility on older Swift versions.

We're also not exporting this, so it has no affect on consuming code. However,
apps that build Valet as a part of their app with Swift 4.1+ will no longer
see warnings about `flatMap` being deprecated.