### PR TITLE
Use -hash instead of -hashValue.

### DIFF
--- a/Sources/SecureEnclaveValet.swift
+++ b/Sources/SecureEnclaveValet.swift
@@ -90,8 +90,8 @@ public final class SecureEnclaveValet: NSObject {
     
     // MARK: Hashable
     
-    public override var hashValue: Int {
-        return service.description.hashValue
+    public override var hash: Int {
+        return service.description.hash
     }
     
     // MARK: Public Properties

--- a/Sources/SecureEnclaveValet.swift
+++ b/Sources/SecureEnclaveValet.swift
@@ -91,7 +91,7 @@ public final class SecureEnclaveValet: NSObject {
     // MARK: Hashable
     
     public override var hash: Int {
-        return service.description.hash
+        return service.description.hashValue
     }
     
     // MARK: Public Properties

--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -91,8 +91,8 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     
     // MARK: Hashable
     
-    public override var hashValue: Int {
-        return service.description.hashValue
+    public override var hash: Int {
+        return service.description.hash
     }
     
     // MARK: Public Properties

--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -92,7 +92,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     // MARK: Hashable
     
     public override var hash: Int {
-        return service.description.hash
+        return service.description.hashValue
     }
     
     // MARK: Public Properties

--- a/Sources/Valet.swift
+++ b/Sources/Valet.swift
@@ -123,7 +123,7 @@ public final class Valet: NSObject, KeychainQueryConvertible {
     // MARK: Hashable
     
     public override var hash: Int {
-        return service.description.hash
+        return service.description.hashValue
     }
     
     // MARK: Public Properties

--- a/Sources/Valet.swift
+++ b/Sources/Valet.swift
@@ -122,8 +122,8 @@ public final class Valet: NSObject, KeychainQueryConvertible {
     
     // MARK: Hashable
     
-    public override var hashValue: Int {
-        return service.description.hashValue
+    public override var hash: Int {
+        return service.description.hash
     }
     
     // MARK: Public Properties


### PR DESCRIPTION
This improves compatibility with Swift 4.2. Fixes #149.