### PR TITLE
Avoid using nullable data initializer

### DIFF
--- a/Sources/Internal/Keychain.swift
+++ b/Sources/Internal/Keychain.swift
@@ -47,7 +47,7 @@ internal final class Keychain {
         } else {
             var secItemQuery = attributes
             secItemQuery[kSecAttrAccount as String] = canaryKey
-            secItemQuery[kSecValueData as String] = canaryValue.data(using: .utf8)
+            secItemQuery[kSecValueData as String] = Data(canaryValue.utf8)
             _ = SecItem.add(attributes: secItemQuery)
             
             return isCanaryValueInKeychain()
@@ -86,7 +86,8 @@ internal final class Keychain {
     // MARK: Setters
     
     internal static func set(string: String, forKey key: String, options: [String: AnyHashable]) -> SecItem.Result {
-        guard let data = string.data(using: .utf8), !data.isEmpty else {
+        let data = Data(string.utf8)
+        guard !data.isEmpty else {
             ErrorHandler.assertionFailure("Can not set an empty value.")
             return .error(errSecParam)
         }

--- a/Tests/MacTests.swift
+++ b/Tests/MacTests.swift
@@ -51,7 +51,7 @@ class ValetMacTests: XCTestCase
         XCTAssertEqual(SecAccessCreate("Access Control List" as CFString, trustedList, &accessList), errSecSuccess)
         var accessListQuery = query
         accessListQuery[kSecAttrAccess as String] = accessList
-        accessListQuery[kSecValueData as String] = vulnValue.data(using: .utf8)
+        accessListQuery[kSecValueData as String] = Data(vulnValue.utf8)
         XCTAssertEqual(SecItemAdd(accessListQuery as CFDictionary, nil), errSecSuccess)
         
         // The potentially vulnerable keychain item should exist in our Valet now.

--- a/Tests/ValetTests.swift
+++ b/Tests/ValetTests.swift
@@ -87,7 +87,7 @@ class ValetTests: XCTestCase
 
     let key = "key"
     let passcode = "topsecret"
-    lazy var passcodeData: Data = { return self.passcode.data(using: .utf8)! }()
+    lazy var passcodeData: Data = { return Data(self.passcode.utf8) }()
     
     // MARK: XCTestCase
 
@@ -374,10 +374,8 @@ class ValetTests: XCTestCase
     // MARK: set(object:forKey:)
     
     func test_setObjectForKey_successfullyUpdatesExistingKey() {
-        guard let firstValue = "first".data(using: .utf8), let secondValue = "second".data(using: .utf8) else {
-            XCTFail()
-            return
-        }
+        let firstValue = Data("first".utf8)
+        let secondValue = Data("second".utf8)
         valet.set(object: firstValue, forKey: key)
         XCTAssertEqual(firstValue, valet.object(forKey: key))
         valet.set(object: secondValue, forKey: key)


### PR DESCRIPTION
Why use a nullable data initializer when you could use a non-null one?

Shout out to @icanzilb for opening my eyes to the existence of this initializer.