### PR TITLE
Use https for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "Tests/xctest-watchOS"]
 	path = Tests/XCTest-watchOS
-	# Use a URL that is relative to github.com/square/valet.git such that our submodules work with both SSH and HTTPS.
-	url = ../../dfed/XCTest-watchOS.git
+	url = https://github.com/dfed/XCTest-watchOS.git


### PR DESCRIPTION
This change fixes Carthage. While it's unfortunate to not allow git cloning of submodules to reflect the method of the original clone (i.e. cloning Valet via `ssh` will now clone `XCTest-watchOS` via `https`), it's better to make sure our distribution mechanisms are not broken.

I'm filing an issue with Carthage to see if they can fix the underlying issue. But for now, I'm putting out a fix.

cc @elyasns 