### PR TITLE
Make unavailable init() public to avoid Swift erroneously declaring other init calls inaccessible

### DIFF
--- a/Sources/SecureEnclaveValet.swift
+++ b/Sources/SecureEnclaveValet.swift
@@ -70,7 +70,7 @@ public final class SecureEnclaveValet: NSObject {
     // MARK: Initialization
     
     @available(*, unavailable)
-    private override init() {
+    public override init() {
         fatalError("Use the class methods above to create usable SecureEnclaveValet objects")
     }
     

--- a/Sources/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/SinglePromptSecureEnclaveValet.swift
@@ -71,7 +71,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     // MARK: Initialization
     
     @available(*, unavailable)
-    private override init() {
+    public override init() {
         fatalError("Use the class methods above to create usable SinglePromptSecureEnclaveValet objects")
     }
     

--- a/Sources/Valet.swift
+++ b/Sources/Valet.swift
@@ -90,7 +90,7 @@ public final class Valet: NSObject, KeychainQueryConvertible {
     // MARK: Initialization
 
     @available(*, unavailable)
-    private override init() {
+    public override init() {
         fatalError("Use the class methods above to create usable Valet objects")
     }
     

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '3.2.2'
+  s.version  = '3.2.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data on iOS, tvOS, watchOS, or macOS without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'


### PR DESCRIPTION
Since `init` is already `unavailable`, there's no reason to make the method `private`. Making the method `public` matches `NSObjct`'s declaration of `init`, so... maybe it'll fix #162?