### PR TITLE
Cocoapods Support For Multiple Swift Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   - osx_image: xcode10.2
     env: ACTION="xcode";SCHEME="Valet watchOS";SDK="watchos5.2";DESTINATION="";XCODE_ACTION="build"
   - osx_image: xcode10.2
-    env: ACTION="pod-lint";SWIFT_VERSION="4.0"
+    env: ACTION="pod-lint";SWIFT_VERSION="5.0"
   - osx_image: xcode10.2
     env: ACTION="carthage"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.6'
+  gem 'cocoapods', '~> 1.7.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.6)!
+  cocoapods (~> 1.7.0)!
 
 BUNDLED WITH
    1.17.3

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '3.2.3'
+  s.version  = '3.2.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data on iOS, tvOS, watchOS, or macOS without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
-  s.swift_version = '4.0'
+  s.swift_version = '4.0', '4.1', '4.2', '5.0'
   s.source_files = 'Sources/**/*.{swift,h}'
   s.public_header_files = 'Sources/*.h'
   s.frameworks = 'Security'


### PR DESCRIPTION
_This is taking changes from #174_ 

Adds support for the new CocoaPods 1.7 feature for allowing multiple Swift version support.