### PR TITLE
Expand test matrix

### DIFF
--- a/Sources/Valet/MigrationResult.swift
+++ b/Sources/Valet/MigrationResult.swift
@@ -21,7 +21,7 @@
 import Foundation
 
 @objc(VALMigrationResult)
-public enum MigrationResult: Int, Equatable {
+public enum MigrationResult: Int, Equatable, CustomStringConvertible {
     /// Migration succeeded.
     case success = 1
     /// Migration failed because the keychain query was not valid.
@@ -42,4 +42,21 @@ public enum MigrationResult: Int, Equatable {
     case couldNotWriteToKeychain
     /// Migration failed because removing the migrated data from the keychain failed.
     case removalFailed
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        switch self {
+        case .success: return "success"
+        case .invalidQuery: return "invalidQuery"
+        case .noItemsToMigrateFound: return "noItemsToMigrateFound"
+        case .couldNotReadKeychain: return "couldNotReadKeychain"
+        case .keyInQueryResultInvalid: return "keyInQueryResultInvalid"
+        case .dataInQueryResultInvalid: return "dataInQueryResultInvalid"
+        case .duplicateKeyInQueryResult: return "duplicateKeyInQueryResult"
+        case .keyInQueryResultAlreadyExistsInValet: return "keyInQueryResultAlreadyExistsInValet"
+        case .couldNotWriteToKeychain: return "couldNotWriteToKeychain"
+        case .removalFailed: return "removalFailed"
+        }
+    }
 }

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
@@ -33,7 +33,8 @@ extension CloudIntegrationTests {
             return
         }
 
-        Valet.iCloudCurrentAndLegacyPermutations(with: valet.identifier).forEach { permutation, legacyValet in
+        let identifier = Identifier(nonEmpty: "BackwardsCompatibilityTest")!
+        Valet.iCloudCurrentAndLegacyPermutations(with: identifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)
 
             XCTAssertNotNil(legacyValet.string(forKey: key))

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -89,7 +89,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
     // MARK: Tests
 
     func test_backwardsCompatibility_withLegacyValet() {
-        Valet.currentAndLegacyPermutations(with: valet.identifier).forEach { permutation, legacyValet in
+        Valet.currentAndLegacyPermutations(with: vanillaValet.identifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)
 
             XCTAssertNotNil(legacyValet.string(forKey: key))

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -28,7 +28,6 @@ class CloudIntegrationTests: XCTestCase
 {
     static let identifier = Valet.sharedAccessGroupIdentifier
     static let accessibility = CloudAccessibility.whenUnlocked
-    let valet = Valet.iCloudValet(with: identifier, accessibility: accessibility)
     var allPermutations: [Valet] {
         return (testEnvironmentIsSigned()
             ? Valet.iCloudPermutations(with: CloudIntegrationTests.identifier) + Valet.iCloudPermutations(with: ValetIntegrationTests.identifier, shared: true)
@@ -44,8 +43,7 @@ class CloudIntegrationTests: XCTestCase
         ErrorHandler.customAssertBody = { _, _, _, _ in
             // Nothing to do here.
         }
-        
-        valet.removeAllObjects()
+
         allPermutations.forEach { testValet in testValet.removeAllObjects() }
     }
     
@@ -54,18 +52,19 @@ class CloudIntegrationTests: XCTestCase
         guard testEnvironmentIsSigned() else {
             return
         }
-        
-        let localValet = Valet.valet(with: valet.identifier, accessibility: valet.accessibility)
+
+        let iCloudValet = Valet.iCloudValet(with: identifier, accessibility: accessibility)
+        let vanillaValet = Valet.valet(with: iCloudValet.identifier, accessibility: iCloudValet.accessibility)
 
         // Setting
-        XCTAssertTrue(valet.set(string: "butts", forKey: "cloud"))
-        XCTAssertEqual("butts", valet.string(forKey: "cloud"))
-        XCTAssertNil(localValet.string(forKey: "cloud"))
+        XCTAssertTrue(iCloudValet.set(string: "butts", forKey: "cloud"))
+        XCTAssertEqual("butts", iCloudValet.string(forKey: "cloud"))
+        XCTAssertNil(vanillaValet.string(forKey: "cloud"))
         
         // Removal
-        XCTAssertTrue(localValet.set(string: "snake people", forKey: "millennials"))
-        XCTAssertTrue(valet.removeObject(forKey: "millennials"))
-        XCTAssertEqual("snake people", localValet.string(forKey: "millennials"))
+        XCTAssertTrue(vanillaValet.set(string: "snake people", forKey: "millennials"))
+        XCTAssertTrue(iCloudValet.removeObject(forKey: "millennials"))
+        XCTAssertEqual("snake people", vanillaValet.string(forKey: "millennials"))
     }
     
     func test_setStringForKey()

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -53,8 +53,9 @@ class CloudIntegrationTests: XCTestCase
             return
         }
 
-        let iCloudValet = Valet.iCloudValet(with: identifier, accessibility: accessibility)
-        let vanillaValet = Valet.valet(with: iCloudValet.identifier, accessibility: iCloudValet.accessibility)
+        let identifier = Identifier(nonEmpty: "DistinctTest")!
+        let vanillaValet = Valet.valet(with: identifier, accessibility: .afterFirstUnlock)
+        let iCloudValet = Valet.iCloudValet(with: identifier, accessibility: .afterFirstUnlock)
 
         // Setting
         XCTAssertTrue(iCloudValet.set(string: "butts", forKey: "cloud"))

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -30,7 +30,7 @@ class CloudIntegrationTests: XCTestCase
     static let accessibility = CloudAccessibility.whenUnlocked
     let valet = Valet.iCloudValet(with: identifier, accessibility: accessibility)
     var allPermutations: [Valet] {
-        (testEnvironmentIsSigned()
+        return (testEnvironmentIsSigned()
             ? Valet.iCloudPermutations(with: CloudIntegrationTests.identifier) + Valet.iCloudPermutations(with: ValetIntegrationTests.identifier, shared: true)
             : [])
     }

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -611,7 +611,8 @@ class ValetIntegrationTests: XCTestCase
         migrationValet.removeAllObjects()
         
         XCTAssertTrue(valet.set(string: passcode, forKey: key))
-        XCTAssertTrue(anotherFlavor.set(string: passcode, forKey:key))
+        let anotherValet = Valet.valet(with: Identifier(nonEmpty: #function)!, accessibility: .whenUnlocked)
+        XCTAssertTrue(anotherValet.set(string: passcode, forKey: key))
 
         let conflictingQuery = [
             kSecClass as String: kSecClassGenericPassword as String,

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -76,7 +76,7 @@ class ValetIntegrationTests: XCTestCase
     static let identifier = Valet.sharedAccessGroupIdentifier
     let valet = Valet.valet(with: identifier, accessibility: .whenUnlocked)
     var allPermutations: [Valet] {
-        Valet.permutations(with: ValetIntegrationTests.identifier)
+        return Valet.permutations(with: ValetIntegrationTests.identifier)
             + (testEnvironmentIsSigned() ? Valet.permutations(with: ValetIntegrationTests.identifier, shared: true) : [])
     }
 

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -80,7 +80,7 @@ class ValetIntegrationTests: XCTestCase
             + (testEnvironmentIsSigned() ? Valet.permutations(with: ValetIntegrationTests.identifier, shared: true) : [])
     }
 
-    // FIXME: Need a different flavor (Synchronizable can't be tested on Mac currently
+    // FIXME: Need a different flavor (Synchronizable must be tested in a signed environment)
     let anotherFlavor = Valet.iCloudValet(with: identifier, accessibility: .whenUnlocked)
 
     let key = "key"

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -616,6 +616,7 @@ class ValetIntegrationTests: XCTestCase
         ]
 
         XCTAssertEqual(.duplicateKeyInQueryResult, migrationValet.migrateObjects(matching: conflictingQuery, removeOnCompletion: false))
+        anotherValet.removeAllObjects()
     }
 
     func test_migrateObjectsMatching_withAccountNameAsData_doesNotRaiseException()

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -144,33 +144,6 @@ class ValetIntegrationTests: XCTestCase
         }
     }
 
-    // MARK: Equality
-
-    func test_valetsWithSameConfiguration_areEqual()
-    {
-        let equalValet = Valet.valet(with: valet.identifier, accessibility: valet.accessibility)
-        XCTAssertTrue(equalValet == valet)
-        XCTAssertTrue(equalValet === valet)
-    }
-
-    func test_differentValetFlavorsWithEquivalentConfiguration_areNotEqual()
-    {
-        XCTAssertFalse(valet == anotherFlavor)
-        XCTAssertFalse(valet === anotherFlavor)
-    }
-
-    func test_valetsWithDifferingIdentifier_areNotEqual()
-    {
-        let differingIdentifier = Valet.valet(with: Identifier(nonEmpty: "nope")!, accessibility: valet.accessibility)
-        XCTAssertNotEqual(valet, differingIdentifier)
-    }
-
-    func test_valetsWithDifferingAccessibility_areNotEqual()
-    {
-        let differingAccessibility = Valet.valet(with: valet.identifier, accessibility: .always)
-        XCTAssertNotEqual(valet, differingAccessibility)
-    }
-
     // MARK: canAccessKeychain
 
     func test_canAccessKeychain()

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -603,10 +603,6 @@ class ValetIntegrationTests: XCTestCase
 
     func test_migrateObjectsMatching_bailsOutIfConflictExistsInQueryResult()
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
-        
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         migrationValet.removeAllObjects()
         

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -222,7 +222,7 @@ class ValetIntegrationTests: XCTestCase
         XCTAssertEqual(differingIdentifier.allKeys(), Set())
 
         // Different Accessibility
-        let differingAccessibility = Valet.valet(with: valet.identifier, accessibility: .always)
+        let differingAccessibility = Valet.valet(with: vanillaValet.identifier, accessibility: .always)
         XCTAssertEqual(differingAccessibility.allKeys(), Set())
 
         // Different Kind
@@ -495,7 +495,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_removeObjectForKey_isDistinctForDifferingAccessibility()
     {
-        let differingAccessibility = Valet.valet(with: valet.identifier, accessibility: .always)
+        let differingAccessibility = Valet.valet(with: vanillaValet.identifier, accessibility: .always)
         XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
 
         XCTAssertTrue(differingAccessibility.removeObject(forKey: key))
@@ -539,7 +539,7 @@ class ValetIntegrationTests: XCTestCase
         vanillaValet.set(string: passcode, forKey: key)
 
         // Test for base query success.
-        XCTAssertEqual(anotherFlavor.migrateObjects(matching: valet.keychainQuery, removeOnCompletion: false), .success)
+        XCTAssertEqual(anotherFlavor.migrateObjects(matching: vanillaValet.keychainQuery, removeOnCompletion: false), .success)
         XCTAssertEqual(passcode, anotherFlavor.string(forKey: key))
 
         var mutableQuery = vanillaValet.keychainQuery
@@ -570,8 +570,8 @@ class ValetIntegrationTests: XCTestCase
         XCTAssertEqual(noItemsFoundError, vanillaValet.migrateObjects(matching: queryWithNoMatches, removeOnCompletion: true))
 
         // Our test Valet has not yet been written to, migration should fail:
-        XCTAssertEqual(noItemsFoundError, anotherFlavor.migrateObjects(matching: valet.keychainQuery, removeOnCompletion: false))
-        XCTAssertEqual(noItemsFoundError, anotherFlavor.migrateObjects(matching: valet.keychainQuery, removeOnCompletion: true))
+        XCTAssertEqual(noItemsFoundError, anotherFlavor.migrateObjects(matching: vanillaValet.keychainQuery, removeOnCompletion: false))
+        XCTAssertEqual(noItemsFoundError, anotherFlavor.migrateObjects(matching: vanillaValet.keychainQuery, removeOnCompletion: true))
     }
 
     func test_migrateObjectsMatching_bailsOutIfConflictExistsInQueryResult()

--- a/Tests/ValetTests/ValetTests.swift
+++ b/Tests/ValetTests/ValetTests.swift
@@ -29,9 +29,6 @@ class ValetTests: XCTestCase
     static let identifier = Identifier(nonEmpty: "valet_testing")!
     let valet = Valet.valet(with: identifier, accessibility: .whenUnlocked)
 
-    // FIXME: Need a different flavor (Synchronizable can't be tested on Mac currently
-    let anotherFlavor = Valet.iCloudValet(with: identifier, accessibility: .whenUnlocked)
-
     // MARK: XCTestCase
 
     override func setUp()
@@ -43,7 +40,6 @@ class ValetTests: XCTestCase
         }
         
         valet.removeAllObjects()
-        anotherFlavor.removeAllObjects()
     }
 
     // MARK: Initialization
@@ -95,6 +91,7 @@ class ValetTests: XCTestCase
 
     func test_differentValetFlavorsWithEquivalentConfiguration_areNotEqual()
     {
+        let anotherFlavor = Valet.iCloudValet(with: ValetTests.identifier, accessibility: .whenUnlocked)
         XCTAssertFalse(valet == anotherFlavor)
         XCTAssertFalse(valet === anotherFlavor)
     }


### PR DESCRIPTION
A lot of our unit tests were testing a single `valet` configuration when they could have been testing an entire suite. This PR updates a bunch of our tests to expand the matrix of options we test on any run.