### PR TITLE
Do not build branch build on every push on PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,8 @@ matrix:
     env: ACTION="pod-lint";SWIFT_VERSION="4.0"
   - osx_image: xcode9
     env: ACTION="carthage"
+
+branches:
+  only:
+  - master
+  - develop--4.0


### PR DESCRIPTION
We don't need to build both a `pr` build and a `push` build on every pull request. This PR makes it so we only build `push` builds for `master` and `develop--4.0`. We'll still have PR builds on every PR, but we won't build every PR build twice.

See [Travis's docs](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) for more info on this change.