### PR TITLE
[Valet 4.0] Fix migrateObjectsFromAlwaysAccessible methods

### DIFF
--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -36,7 +36,17 @@ internal enum Service: CustomStringConvertible, Equatable {
     internal var description: String {
         secService
     }
-    
+
+    // MARK: Internal Static Methods
+
+    internal static func standard(with configuration: Configuration, identifier: Identifier, accessibilityDescription: String) -> String {
+        "VAL_\(configuration.description)_initWithIdentifier:accessibility:_\(identifier)_\(accessibilityDescription)"
+    }
+
+    internal static func sharedAccessGroup(with configuration: Configuration, identifier: Identifier, accessibilityDescription: String) -> String {
+        "VAL_\(configuration.description)_initWithSharedAccessGroupIdentifier:accessibility:_\(identifier)_\(accessibilityDescription)"
+    }
+
     // MARK: Internal Methods
     
     internal func generateBaseQuery() -> [String : AnyHashable]? {
@@ -82,9 +92,9 @@ internal enum Service: CustomStringConvertible, Equatable {
         var service: String
         switch self {
         case let .standard(identifier, configuration):
-            service = "VAL_\(configuration.description)_initWithIdentifier:accessibility:_\(identifier)_\(configuration.accessibility.description)"
+            service = Service.standard(with: configuration, identifier: identifier, accessibilityDescription: configuration.accessibility.description)
         case let .sharedAccessGroup(identifier, configuration):
-            service = "VAL_\(configuration.description)_initWithSharedAccessGroupIdentifier:accessibility:_\(identifier)_\(configuration.accessibility.description)"
+            service = Service.sharedAccessGroup(with: configuration, identifier: identifier, accessibilityDescription: configuration.accessibility.description)
         }
         
         let configuration: Configuration

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -288,6 +288,15 @@ public final class Valet: NSObject {
             return .couldNotReadKeychain
         }
         keychainQuery[kSecAttrAccessible as String] = "dk" // kSecAttrAccessibleAlways, but with the value hardcoded to avoid a build warning.
+        let accessibilityDescription = "AccessibleAlways"
+        let serviceAttribute: String
+        switch service {
+        case .sharedAccessGroup:
+            serviceAttribute = Service.sharedAccessGroup(with: configuration, identifier: identifier, accessibilityDescription: accessibilityDescription)
+        case .standard:
+            serviceAttribute = Service.standard(with: configuration, identifier: identifier, accessibilityDescription: accessibilityDescription)
+        }
+        keychainQuery[kSecAttrService as String] = serviceAttribute
         return migrateObjects(matching: keychainQuery, removeOnCompletion: removeOnCompletion)
     }
 
@@ -302,6 +311,15 @@ public final class Valet: NSObject {
             return .couldNotReadKeychain
         }
         keychainQuery[kSecAttrAccessible as String] = "dku" // kSecAttrAccessibleAlwaysThisDeviceOnly, but with the value hardcoded to avoid a build warning.
+        let accessibilityDescription = "AccessibleAlwaysThisDeviceOnly"
+        let serviceAttribute: String
+        switch service {
+        case .sharedAccessGroup:
+            serviceAttribute = Service.sharedAccessGroup(with: configuration, identifier: identifier, accessibilityDescription: accessibilityDescription)
+        case .standard:
+            serviceAttribute = Service.standard(with: configuration, identifier: identifier, accessibilityDescription: accessibilityDescription)
+        }
+        keychainQuery[kSecAttrService as String] = serviceAttribute
         return migrateObjects(matching: keychainQuery, removeOnCompletion: removeOnCompletion)
     }
 

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -68,14 +68,14 @@ internal extension Valet {
     // MARK: Permutations
 
     class func currentAndLegacyPermutations(with identifier: Identifier, shared: Bool = false) -> [(Valet, VALLegacyValet)] {
-        return permutations(with: identifier, shared: shared).map {
-            return ($0, $0.legacyValet)
+        permutations(with: identifier, shared: shared).map {
+            ($0, $0.legacyValet)
         }
     }
 
     class func iCloudCurrentAndLegacyPermutations(with identifier: Identifier, shared: Bool = false) -> [(Valet, VALSynchronizableValet)] {
-        return iCloudPermutations(with: identifier, shared: shared).map {
-            return ($0, $0.legacyValet as! VALSynchronizableValet)
+        iCloudPermutations(with: identifier, shared: shared).map {
+            ($0, $0.legacyValet as! VALSynchronizableValet)
         }
     }
 }
@@ -105,6 +105,48 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
             XCTAssertNotNil(legacyValet.string(forKey: key))
             XCTAssertEqual(legacyValet.string(forKey: key), permutation.string(forKey: key), "\(permutation) was not able to read from legacy counterpart: \(legacyValet)")
         }
+    }
+
+    func test_migrateObjectsFromAlwaysAccessibleValet_forwardsCompatibility_fromLegacyValet() {
+        let alwaysAccessibleLegacyValet = VALLegacyValet(identifier: vanillaValet.identifier.description, accessibility: .always)!
+        alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
+
+        let valet = Valet.valet(with: vanillaValet.identifier, accessibility: .afterFirstUnlock)
+        XCTAssertEqual(valet.migrateObjectsFromAlwaysAccessibleValet(removeOnCompletion: true), .success)
+        XCTAssertEqual(valet.string(forKey: key), passcode)
+    }
+
+    func test_migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet_forwardsCompatibility_fromLegacyValet() {
+        let alwaysAccessibleLegacyValet = VALLegacyValet(identifier: vanillaValet.identifier.description, accessibility: .alwaysThisDeviceOnly)!
+        alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
+
+        let valet = Valet.valet(with: vanillaValet.identifier, accessibility: .afterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(valet.migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet(removeOnCompletion: true), .success)
+        XCTAssertEqual(valet.string(forKey: key), passcode)
+    }
+
+    func test_migrateObjectsFromAlwaysAccessibleValet_forwardsCompatibility_withLegacySharedAccessGroupValet() {
+        guard testEnvironmentIsSigned() else {
+            return
+        }
+        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.description, accessibility: .always)!
+        alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
+
+        let valet = Valet.sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessibility: .afterFirstUnlock)
+        XCTAssertEqual(valet.migrateObjectsFromAlwaysAccessibleValet(removeOnCompletion: true), .success)
+        XCTAssertEqual(valet.string(forKey: key), passcode)
+    }
+
+    func test_migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet_forwardsCompatibility_withLegacySharedAccessGroupValet() {
+        guard testEnvironmentIsSigned() else {
+            return
+        }
+        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.description, accessibility: .alwaysThisDeviceOnly)!
+        alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
+
+        let valet = Valet.sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessibility: .afterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(valet.migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet(removeOnCompletion: true), .success)
+        XCTAssertEqual(valet.string(forKey: key), passcode)
     }
 
 }


### PR DESCRIPTION
I realized that the `migrateObjectsFromAlwaysAccessible` methods were not using the correct `service`. This PR fixes that, and writes tests.