### PR TITLE
[Valet 4.0] Standardize method naming

### DIFF
--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -85,17 +85,17 @@ internal final class Keychain {
     
     // MARK: Setters
     
-    internal static func set(string: String, forKey key: String, options: [String: AnyHashable]) -> SecItem.Result {
+    internal static func setString(_ string: String, forKey key: String, options: [String: AnyHashable]) -> SecItem.Result {
         let data = Data(string.utf8)
         guard !data.isEmpty else {
             ErrorHandler.assertionFailure("Can not set an empty value.")
             return .error(errSecParam)
         }
         
-        return set(object: data, forKey: key, options: options)
+        return setObject(data, forKey: key, options: options)
     }
     
-    internal static func set(object: Data, forKey key: String, options: [String: AnyHashable]) -> SecItem.Result {
+    internal static func setObject(_ object: Data, forKey key: String, options: [String: AnyHashable]) -> SecItem.Result {
         guard !key.isEmpty else {
             ErrorHandler.assertionFailure("Can not set a value with an empty key.")
             return .error(errSecParam)
@@ -375,7 +375,7 @@ internal final class Keychain {
                 return .dataInQueryResultInvalid
             }
             
-            switch Keychain.set(object: value, forKey: key, options: destinationAttributes) {
+            switch Keychain.setObject(value, forKey: key, options: destinationAttributes) {
             case .success:
                 alreadyMigratedKeys.append(key)
                 

--- a/Sources/Valet/SecureEnclave.swift
+++ b/Sources/Valet/SecureEnclave.swift
@@ -92,11 +92,11 @@ public final class SecureEnclave {
     /// - parameter options: A base query used to scope the calls in the keychain.
     /// - returns: `false` if the keychain is not accessible.
     @discardableResult
-    internal static func set(object: Data, forKey key: String, options: [String : AnyHashable]) -> Bool {
+    internal static func setObject(_ object: Data, forKey key: String, options: [String : AnyHashable]) -> Bool {
         // Remove the key before trying to set it. This will prevent us from calling SecItemUpdate on an item stored on the Secure Enclave, which would cause iOS to prompt the user for authentication.
         _ = Keychain.removeObject(forKey: key, options: options)
         
-        return Keychain.set(object: object, forKey: key, options: options).didSucceed
+        return Keychain.setObject(object, forKey: key, options: options).didSucceed
     }
     
     /// - parameter key: A Key used to retrieve the desired object from the keychain.
@@ -134,11 +134,11 @@ public final class SecureEnclave {
     /// - parameter options: A base query used to scope the calls in the keychain.
     /// - returns: `true` if the operation succeeded, or `false` if the keychain is not accessible.
     @discardableResult
-    internal static func set(string: String, forKey key: String, options: [String : AnyHashable]) -> Bool {
+    internal static func setString(_ string: String, forKey key: String, options: [String : AnyHashable]) -> Bool {
         // Remove the key before trying to set it. This will prevent us from calling SecItemUpdate on an item stored on the Secure Enclave, which would cause iOS to prompt the user for authentication.
         _ = Keychain.removeObject(forKey: key, options: options)
         
-        return Keychain.set(string: string, forKey: key, options: options).didSucceed
+        return Keychain.setString(string, forKey: key, options: options).didSucceed
     }
     
     /// - parameter key: A Key used to retrieve the desired object from the keychain.

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -118,14 +118,14 @@ public final class SecureEnclaveValet: NSObject {
     /// - parameter object: A Data value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `object` from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(setObject:forKey:)
+    @objc
     @discardableResult
-    public func set(object: Data, forKey key: String) -> Bool {
+    public func setObject(_ object: Data, forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
                 return false
             }
-            return SecureEnclave.set(object: object, forKey: key, options: keychainQuery)
+            return SecureEnclave.setObject(object, forKey: key, options: keychainQuery)
         }
     }
     
@@ -144,7 +144,7 @@ public final class SecureEnclaveValet: NSObject {
     /// - parameter key: The key to look up in the keychain.
     /// - returns: `true` if a value has been set for the given key, `false` otherwise. Will return `false` if the keychain is not accessible.
     /// - note: Will never prompt the user for Face ID, Touch ID, or password.
-    @objc(containsObjectForKey:)
+    @objc
     public func containsObject(forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -157,14 +157,14 @@ public final class SecureEnclaveValet: NSObject {
     /// - parameter string: A String value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `string` from the keychain.
     /// - returns: `true` if the operation succeeded, or `false` if the keychain is not accessible.
-    @objc(setString:forKey:)
+    @objc
     @discardableResult
-    public func set(string: String, forKey key: String) -> Bool {
+    public func setString(_ string: String, forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
                 return false
             }
-            return SecureEnclave.set(string: string, forKey: key, options: keychainQuery)
+            return SecureEnclave.setString(string, forKey: key, options: keychainQuery)
         }
     }
     
@@ -182,7 +182,7 @@ public final class SecureEnclaveValet: NSObject {
     
     /// Removes a key/object pair from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(removeObjectForKey:)
+    @objc
     @discardableResult
     public func removeObject(forKey key: String) -> Bool {
         execute(in: lock) {
@@ -211,7 +211,7 @@ public final class SecureEnclaveValet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsMatchingQuery:removeOnCompletion:)
+    @objc
     public func migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool) -> MigrationResult {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -226,7 +226,7 @@ public final class SecureEnclaveValet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychfain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsFromValet:removeOnCompletion:)
+    @objc
     public func migrateObjects(from valet: Valet, removeOnCompletion: Bool) -> MigrationResult {
         guard let keychainQuery = valet.keychainQuery else {
             return .couldNotReadKeychain

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -122,14 +122,14 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - parameter object: A Data value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `object` from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(setObject:forKey:)
+    @objc
     @discardableResult
-    public func set(object: Data, forKey key: String) -> Bool {
+    public func setObject(_ object: Data, forKey key: String) -> Bool {
         return execute(in: lock) {
             guard let baseKeychainQuery = baseKeychainQuery else {
                 return false
             }
-            return SecureEnclave.set(object: object, forKey: key, options: baseKeychainQuery)
+            return SecureEnclave.setObject(object, forKey: key, options: baseKeychainQuery)
         }
     }
     
@@ -148,7 +148,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - parameter key: The key to look up in the keychain.
     /// - returns: `true` if a value has been set for the given key, `false` otherwise. Will return `false` if the keychain is not accessible.
     /// - note: Will never prompt the user for Face ID, Touch ID, or password.
-    @objc(containsObjectForKey:)
+    @objc
     public func containsObject(forKey key: String) -> Bool {
         return execute(in: lock) {
             guard let baseKeychainQuery = baseKeychainQuery else {
@@ -161,14 +161,14 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - parameter string: A String value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `string` from the keychain.
     /// - returns: `true` if the operation succeeded, or `false` if the keychain is not accessible.
-    @objc(setString:forKey:)
+    @objc
     @discardableResult
-    public func set(string: String, forKey key: String) -> Bool {
+    public func setString(_ string: String, forKey key: String) -> Bool {
         return execute(in: lock) {
             guard let baseKeychainQuery = baseKeychainQuery else {
                 return false
             }
-            return SecureEnclave.set(string: string, forKey: key, options: baseKeychainQuery)
+            return SecureEnclave.setString(string, forKey: key, options: baseKeychainQuery)
         }
     }
     
@@ -195,7 +195,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     
     /// - parameter userPrompt: The prompt displayed to the user in Apple's Face ID, Touch ID, or passcode entry UI. If the `SinglePromptSecureEnclaveValet` has already been unlocked, no prompt will be shown.
     /// - returns: The set of all (String) keys currently stored in this Valet instance. Will return an empty set if the keychain is not accessible.
-    @objc(allKeysWithUserPrompt:)
+    @objc
     public func allKeys(userPrompt: String) -> Set<String> {
         return execute(in: lock) {
             guard let continuedAuthenticationKeychainQuery = continuedAuthenticationKeychainQuery else {
@@ -212,7 +212,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     
     /// Removes a key/object pair from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(removeObjectForKey:)
+    @objc
     @discardableResult
     public func removeObject(forKey key: String) -> Bool {
         return execute(in: lock) {
@@ -241,7 +241,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsMatchingQuery:removeOnCompletion:)
+    @objc
     public func migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool) -> MigrationResult {
         return execute(in: lock) {
             guard let baseKeychainQuery = baseKeychainQuery else {
@@ -256,7 +256,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychfain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsFromValet:removeOnCompletion:)
+    @objc
     public func migrateObjects(from valet: Valet, removeOnCompletion: Bool) -> MigrationResult {
         guard let keychainQuery = valet.keychainQuery else {
             return .couldNotReadKeychain

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -151,20 +151,20 @@ public final class Valet: NSObject {
     /// - parameter object: A Data value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `object` from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(setObject:forKey:)
+    @objc
     @discardableResult
-    public func set(object: Data, forKey key: String) -> Bool {
+    public func setObject(_ object: Data, forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
                 return false
             }
-            return Keychain.set(object: object, forKey: key, options: keychainQuery).didSucceed
+            return Keychain.setObject(object, forKey: key, options: keychainQuery).didSucceed
         }
     }
     
     /// - parameter key: A Key used to retrieve the desired object from the keychain.
     /// - returns: The data currently stored in the keychain for the provided key. Returns `nil` if no object exists in the keychain for the specified key, or if the keychain is inaccessible.
-    @objc(objectForKey:)
+    @objc
     public func object(forKey key: String) -> Data? {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -176,7 +176,7 @@ public final class Valet: NSObject {
     
     /// - parameter key: The key to look up in the keychain.
     /// - returns: `true` if a value has been set for the given key, `false` otherwise. Will return `false` if the keychain is not accessible.
-    @objc(containsObjectForKey:)
+    @objc
     public func containsObject(forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -189,20 +189,20 @@ public final class Valet: NSObject {
     /// - parameter string: A String value to be inserted into the keychain.
     /// - parameter key: A Key that can be used to retrieve the `string` from the keychain.
     /// - returns: `true` if the operation succeeded, or `false` if the keychain is not accessible.
-    @objc(setString:forKey:)
+    @objc
     @discardableResult
-    public func set(string: String, forKey key: String) -> Bool {
+    public func setString(_ string: String, forKey key: String) -> Bool {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
                 return false
             }
-            return Keychain.set(string: string, forKey: key, options: keychainQuery).didSucceed
+            return Keychain.setString(string, forKey: key, options: keychainQuery).didSucceed
         }
     }
     
     /// - parameter key: A Key used to retrieve the desired object from the keychain.
     /// - returns: The string currently stored in the keychain for the provided key. Returns `nil` if no string exists in the keychain for the specified key, or if the keychain is inaccessible.
-    @objc(stringForKey:)
+    @objc
     public func string(forKey key: String) -> String? {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -225,7 +225,7 @@ public final class Valet: NSObject {
     
     /// Removes a key/object pair from the keychain.
     /// - returns: `false` if the keychain is not accessible.
-    @objc(removeObjectForKey:)
+    @objc
     @discardableResult
     public func removeObject(forKey key: String) -> Bool {
         execute(in: lock) {
@@ -254,7 +254,7 @@ public final class Valet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsMatchingQuery:removeOnCompletion:)
+    @objc
     public func migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool) -> MigrationResult {
         execute(in: lock) {
             guard let keychainQuery = keychainQuery else {
@@ -269,7 +269,7 @@ public final class Valet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsFromValet:removeOnCompletion:)
+    @objc
     public func migrateObjects(from valet: Valet, removeOnCompletion: Bool) -> MigrationResult {
         guard let keychainQuery = valet.keychainQuery else {
             return .couldNotReadKeychain
@@ -282,7 +282,7 @@ public final class Valet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsFromAlwaysAccessibleValetAndRemoveOnCompletion:)
+    @objc
     public func migrateObjectsFromAlwaysAccessibleValet(removeOnCompletion: Bool) -> MigrationResult {
         guard var keychainQuery = keychainQuery else {
             return .couldNotReadKeychain
@@ -313,7 +313,7 @@ public final class Valet: NSObject {
     /// - parameter removeOnCompletion: If `true`, the migrated data will be removed from the keychain if the migration succeeds.
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs.
-    @objc(migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValetAndRemoveOnCompletion:)
+    @objc
     public func migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet(removeOnCompletion: Bool) -> MigrationResult {
         guard var keychainQuery = keychainQuery else {
             return .couldNotReadKeychain
@@ -344,7 +344,7 @@ public final class Valet: NSObject {
     /// - returns: Whether the migration succeeded or failed.
     /// - note: The keychain is not modified if a failure occurs. This method can only be called from macOS 10.15 or later.
     @available(macOS 10.15, *)
-    @objc(migrateObjectsFromPreCatalina)
+    @objc
     public func migrateObjectsFromPreCatalina() -> MigrationResult {
         guard var keychainQuery = keychainQuery else {
             return .couldNotReadKeychain

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -58,12 +58,12 @@ class CloudIntegrationTests: XCTestCase
         let iCloudValet = Valet.iCloudValet(with: identifier, accessibility: .afterFirstUnlock)
 
         // Setting
-        XCTAssertTrue(iCloudValet.set(string: "butts", forKey: "cloud"))
+        XCTAssertTrue(iCloudValet.setString("butts", forKey: "cloud"))
         XCTAssertEqual("butts", iCloudValet.string(forKey: "cloud"))
         XCTAssertNil(vanillaValet.string(forKey: "cloud"))
         
         // Removal
-        XCTAssertTrue(vanillaValet.set(string: "snake people", forKey: "millennials"))
+        XCTAssertTrue(vanillaValet.setString("snake people", forKey: "millennials"))
         XCTAssertTrue(iCloudValet.removeObject(forKey: "millennials"))
         XCTAssertEqual("snake people", vanillaValet.string(forKey: "millennials"))
     }
@@ -72,7 +72,7 @@ class CloudIntegrationTests: XCTestCase
     {
         allPermutations.forEach { valet in
             XCTAssertNil(valet.string(forKey: key), "\(valet) read item from keychain that should not exist")
-            XCTAssertTrue(valet.set(string: passcode, forKey: key), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString(passcode, forKey: key), "\(valet) could not set item in keychain")
             XCTAssertEqual(passcode, valet.string(forKey: key))
         }
     }
@@ -80,7 +80,7 @@ class CloudIntegrationTests: XCTestCase
     func test_removeObjectForKey()
     {
         allPermutations.forEach { valet in
-            XCTAssertTrue(valet.set(string: passcode, forKey: key), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString(passcode, forKey: key), "\(valet) could not set item in keychain")
             XCTAssertEqual(passcode, valet.string(forKey: key), "\(valet) read incorrect value from keychain.")
 
             XCTAssertTrue(valet.removeObject(forKey: key), "\(valet) did not remove item from keychain.")

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -84,7 +84,7 @@ class ValetMacTests: XCTestCase
 
         // Update the vulnerable value with Valet - we should have deleted the existing item, making the entry no longer vulnerable.
         let updatedValue = "Safe"
-        XCTAssertTrue(valet.set(string: updatedValue, forKey: vulnKey))
+        XCTAssertTrue(valet.setString(updatedValue, forKey: vulnKey))
 
         // We should no longer be able to access the keychain item via the ref.
         let queryWithVulnerableReferenceAndAttributes = [

--- a/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
@@ -50,7 +50,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(valet.set(string: passcode, forKey: key))
+        XCTAssertTrue(valet.setString(passcode, forKey: key))
         let equivalentValet = SecureEnclaveValet.valet(with: valet.identifier, accessControl: valet.accessControl)
         XCTAssertEqual(valet, equivalentValet)
         XCTAssertEqual(.success(passcode), equivalentValet.string(forKey: key, withPrompt: ""))
@@ -62,7 +62,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(valet.set(string: passcode, forKey: key))
+        XCTAssertTrue(valet.setString(passcode, forKey: key))
         let equivalentValet = SecureEnclaveValet.valet(with: valet.identifier, accessControl: .devicePasscode)
         XCTAssertNotEqual(valet, equivalentValet)
         XCTAssertEqual(.success(passcode), valet.string(forKey: key, withPrompt: ""))
@@ -149,7 +149,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
         ]
         
         for (key, value) in keyValuePairs {
-            plainOldValet.set(string: value, forKey: key)
+            plainOldValet.setString(value, forKey: key)
         }
         
         XCTAssertEqual(.success, valet.migrateObjects(from: plainOldValet, removeOnCompletion: true))
@@ -178,7 +178,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
         
         let keyStringPairToMigrateMap = ["foo" : "bar", "testing" : "migration", "is" : "quite", "entertaining" : "if", "you" : "don't", "screw" : "up"]
         for (key, value) in keyStringPairToMigrateMap {
-            XCTAssertTrue(otherValet.set(string: value, forKey: key))
+            XCTAssertTrue(otherValet.setString(value, forKey: key))
         }
         
         XCTAssertTrue(valet.canAccessKeychain())

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -50,7 +50,7 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(valet.set(string: passcode, forKey: key))
+        XCTAssertTrue(valet.setString(passcode, forKey: key))
         let equivalentValet = SinglePromptSecureEnclaveValet.valet(with: valet.identifier, accessControl: valet.accessControl)
         XCTAssertEqual(valet, equivalentValet)
         XCTAssertEqual(.success(passcode), equivalentValet.string(forKey: key, withPrompt: ""))
@@ -62,7 +62,7 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(valet.set(string: passcode, forKey: key))
+        XCTAssertTrue(valet.setString(passcode, forKey: key))
         let equivalentValet = SecureEnclaveValet.valet(with: valet.identifier, accessControl: .devicePasscode)
         XCTAssertNotEqual(valet, equivalentValet)
         XCTAssertEqual(.success(passcode), valet.string(forKey: key, withPrompt: ""))
@@ -79,10 +79,10 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         
         XCTAssertEqual(valet.allKeys(userPrompt: ""), Set())
         
-        XCTAssertTrue(valet.set(string: passcode, forKey: key))
+        XCTAssertTrue(valet.setString(passcode, forKey: key))
         XCTAssertEqual(valet.allKeys(userPrompt: ""), Set(arrayLiteral: key))
         
-        XCTAssertTrue(valet.set(string: "monster", forKey: "cookie"))
+        XCTAssertTrue(valet.setString("monster", forKey: "cookie"))
         XCTAssertEqual(valet.allKeys(userPrompt: ""), Set(arrayLiteral: key, "cookie"))
         
         valet.removeAllObjects()
@@ -171,7 +171,7 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         ]
         
         for (key, value) in keyValuePairs {
-            plainOldValet.set(string: value, forKey: key)
+            plainOldValet.setString(value, forKey: key)
         }
         
         XCTAssertEqual(.success, valet.migrateObjects(from: plainOldValet, removeOnCompletion: true))
@@ -200,7 +200,7 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         
         let keyStringPairToMigrateMap = ["foo" : "bar", "testing" : "migration", "is" : "quite", "entertaining" : "if", "you" : "don't", "screw" : "up"]
         for (key, value) in keyStringPairToMigrateMap {
-            XCTAssertTrue(otherValet.set(string: value, forKey: key))
+            XCTAssertTrue(otherValet.setString(value, forKey: key))
         }
         
         XCTAssertTrue(valet.canAccessKeychain())

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -186,7 +186,7 @@ class ValetIntegrationTests: XCTestCase
         allPermutations.forEach { valet in
             XCTAssertFalse(valet.containsObject(forKey: key), "\(valet) found object for key that should not exist")
 
-            XCTAssertTrue(valet.set(string: passcode, forKey: key), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString(passcode, forKey: key), "\(valet) could not set item in keychain")
             XCTAssertTrue(valet.containsObject(forKey: key), "\(valet) could not find item it has set in keychain")
 
             XCTAssertTrue(valet.removeObject(forKey: key), "\(valet) could not remove item in keychain")
@@ -201,10 +201,10 @@ class ValetIntegrationTests: XCTestCase
         allPermutations.forEach { valet in
             XCTAssertEqual(valet.allKeys(), Set(), "\(valet) found keys that should not exist")
 
-            XCTAssertTrue(valet.set(string: passcode, forKey: key), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString(passcode, forKey: key), "\(valet) could not set item in keychain")
             XCTAssertEqual(valet.allKeys(), Set(arrayLiteral: key))
 
-            XCTAssertTrue(valet.set(string: "monster", forKey: "cookie"), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString("monster", forKey: "cookie"), "\(valet) could not set item in keychain")
             XCTAssertEqual(valet.allKeys(), Set(arrayLiteral: key, "cookie"))
 
             valet.removeAllObjects()
@@ -222,7 +222,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_allKeys_remainsUntouchedForUnequalValets()
     {
-        vanillaValet.set(string: passcode, forKey: key)
+        vanillaValet.setString(passcode, forKey: key)
         XCTAssertEqual(vanillaValet.allKeys(), Set(arrayLiteral: key))
 
         // Different Identifier
@@ -249,7 +249,7 @@ class ValetIntegrationTests: XCTestCase
     func test_stringForKey_retrievesStringForValidKey()
     {
         allPermutations.forEach { valet in
-            XCTAssertTrue(valet.set(string: passcode, forKey: key), "\(valet) could not set item in keychain")
+            XCTAssertTrue(valet.setString(passcode, forKey: key), "\(valet) could not set item in keychain")
             XCTAssertEqual(passcode, valet.string(forKey: key))
         }
     }
@@ -259,13 +259,13 @@ class ValetIntegrationTests: XCTestCase
         let equalValet = Valet.valet(with: vanillaValet.identifier, accessibility: vanillaValet.accessibility)
         XCTAssertEqual(0, equalValet.allKeys().count)
         XCTAssertEqual(vanillaValet, equalValet)
-        XCTAssertTrue(vanillaValet.set(string: "monster", forKey: "cookie"))
+        XCTAssertTrue(vanillaValet.setString("monster", forKey: "cookie"))
         XCTAssertEqual("monster", equalValet.string(forKey: "cookie"))
     }
 
     func test_stringForKey_withDifferingIdentifier_isNil()
     {
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
         XCTAssertEqual(passcode, vanillaValet.string(forKey: key))
         
         let differingIdentifier = Valet.valet(with: Identifier(nonEmpty: "wat")!, accessibility: vanillaValet.accessibility)
@@ -274,7 +274,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_stringForKey_withDifferingAccessibility_isNil()
     {
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
         XCTAssertEqual(passcode, vanillaValet.string(forKey: key))
         
         let differingAccessibility = Valet.valet(with: vanillaValet.identifier, accessibility: .afterFirstUnlockThisDeviceOnly)
@@ -287,7 +287,7 @@ class ValetIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(vanillaValet.set(string: "monster", forKey: "cookie"))
+        XCTAssertTrue(vanillaValet.setString("monster", forKey: "cookie"))
         XCTAssertEqual("monster", vanillaValet.string(forKey: "cookie"))
 
         XCTAssertNil(anotherFlavor.string(forKey: "cookie"))
@@ -323,22 +323,22 @@ class ValetIntegrationTests: XCTestCase
     {
         allPermutations.forEach { valet in
             XCTAssertNil(valet.string(forKey: key))
-            valet.set(string: "1", forKey: key)
+            valet.setString("1", forKey: key)
             XCTAssertEqual("1", valet.string(forKey: key))
-            valet.set(string: "2", forKey: key)
+            valet.setString("2", forKey: key)
             XCTAssertEqual("2", valet.string(forKey: key))
         }
     }
     
     func test_setStringForKey_failsForInvalidValue() {
         allPermutations.forEach { valet in
-            XCTAssertFalse(valet.set(string: "", forKey: key))
+            XCTAssertFalse(valet.setString("", forKey: key))
         }
     }
     
     func test_setStringForKey_failsForInvalidKey() {
         allPermutations.forEach { valet in
-            XCTAssertFalse(valet.set(string: passcode, forKey: ""))
+            XCTAssertFalse(valet.setString(passcode, forKey: ""))
         }
     }
     
@@ -352,7 +352,7 @@ class ValetIntegrationTests: XCTestCase
     
     func test_objectForKey_succeedsForValidKey() {
         allPermutations.forEach { valet in
-            valet.set(object: passcodeData, forKey: key)
+            valet.setObject(passcodeData, forKey: key)
             XCTAssertEqual(passcodeData, valet.object(forKey: key))
         }
     }
@@ -361,12 +361,12 @@ class ValetIntegrationTests: XCTestCase
         let equalValet = Valet.valet(with: vanillaValet.identifier, accessibility: vanillaValet.accessibility)
         XCTAssertEqual(0, equalValet.allKeys().count)
         XCTAssertEqual(vanillaValet, equalValet)
-        XCTAssertTrue(vanillaValet.set(object: passcodeData, forKey: key))
+        XCTAssertTrue(vanillaValet.setObject(passcodeData, forKey: key))
         XCTAssertEqual(passcodeData, equalValet.object(forKey: key))
     }
     
     func test_objectForKey_withDifferingIdentifier_isNil() {
-        XCTAssertTrue(vanillaValet.set(object: passcodeData, forKey: key))
+        XCTAssertTrue(vanillaValet.setObject(passcodeData, forKey: key))
         XCTAssertEqual(passcodeData, vanillaValet.object(forKey: key))
         
         let differingIdentifier = Valet.valet(with: Identifier(nonEmpty: "wat")!, accessibility: vanillaValet.accessibility)
@@ -374,7 +374,7 @@ class ValetIntegrationTests: XCTestCase
     }
     
     func test_objectForKey_withDifferingAccessibility_isNil() {
-        XCTAssertTrue(vanillaValet.set(object: passcodeData, forKey: key))
+        XCTAssertTrue(vanillaValet.setObject(passcodeData, forKey: key))
         XCTAssertEqual(passcodeData, vanillaValet.object(forKey: key))
         
         let differingAccessibility = Valet.valet(with: vanillaValet.identifier, accessibility: .afterFirstUnlockThisDeviceOnly)
@@ -386,7 +386,7 @@ class ValetIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(vanillaValet.set(object: passcodeData, forKey: key))
+        XCTAssertTrue(vanillaValet.setObject(passcodeData, forKey: key))
         XCTAssertEqual(passcodeData, vanillaValet.object(forKey: key))
         
         XCTAssertNil(anotherFlavor.object(forKey: key))
@@ -398,16 +398,16 @@ class ValetIntegrationTests: XCTestCase
         allPermutations.forEach { valet in
             let firstValue = Data("first".utf8)
             let secondValue = Data("second".utf8)
-            valet.set(object: firstValue, forKey: key)
+            valet.setObject(firstValue, forKey: key)
             XCTAssertEqual(firstValue, valet.object(forKey: key))
-            valet.set(object: secondValue, forKey: key)
+            valet.setObject(secondValue, forKey: key)
             XCTAssertEqual(secondValue, valet.object(forKey: key))
         }
     }
     
     func test_setObjectForKey_failsForInvalidKey() {
         allPermutations.forEach { valet in
-            XCTAssertFalse(valet.set(object: passcodeData, forKey: ""))
+            XCTAssertFalse(valet.setObject(passcodeData, forKey: ""))
         }
     }
     
@@ -415,7 +415,7 @@ class ValetIntegrationTests: XCTestCase
         allPermutations.forEach { valet in
             let emptyData = Data()
             XCTAssertTrue(emptyData.isEmpty)
-            XCTAssertFalse(valet.set(object: emptyData, forKey: key))
+            XCTAssertFalse(valet.setObject(emptyData, forKey: key))
         }
     }
     
@@ -423,7 +423,7 @@ class ValetIntegrationTests: XCTestCase
     
     func test_stringForKey_succeedsForDataBackedByString() {
         allPermutations.forEach { valet in
-            XCTAssertTrue(valet.set(object: passcodeData, forKey: key))
+            XCTAssertTrue(valet.setObject(passcodeData, forKey: key))
             XCTAssertEqual(passcode, valet.string(forKey: key))
         }
     }
@@ -432,14 +432,14 @@ class ValetIntegrationTests: XCTestCase
         allPermutations.forEach { valet in
             let dictionary = [ "that's no" : "moon" ]
             let nonStringData = NSKeyedArchiver.archivedData(withRootObject: dictionary)
-            XCTAssertTrue(valet.set(object: nonStringData, forKey: key))
+            XCTAssertTrue(valet.setObject(nonStringData, forKey: key))
             XCTAssertNil(valet.string(forKey: key))
         }
     }
     
     func test_objectForKey_succeedsForStrings() {
         allPermutations.forEach { valet in
-            XCTAssertTrue(valet.set(string: passcode, forKey: key))
+            XCTAssertTrue(valet.setString(passcode, forKey: key))
             XCTAssertEqual(passcodeData, valet.object(forKey: key))
         }
     }
@@ -452,7 +452,7 @@ class ValetIntegrationTests: XCTestCase
         let removeQueue = DispatchQueue(label: "Remove Object Queue", attributes: .concurrent)
 
         for _ in 1...50 {
-            setQueue.async { XCTAssertTrue(self.vanillaValet.set(string: self.passcode, forKey: self.key)) }
+            setQueue.async { XCTAssertTrue(self.vanillaValet.setString(self.passcode, forKey: self.key)) }
             removeQueue.async { XCTAssertTrue(self.vanillaValet.removeObject(forKey: self.key)) }
         }
         
@@ -477,7 +477,7 @@ class ValetIntegrationTests: XCTestCase
         let expectation = self.expectation(description: #function)
 
         setStringQueue.async {
-            XCTAssertTrue(self.vanillaValet.set(string: self.passcode, forKey: self.key))
+            XCTAssertTrue(self.vanillaValet.setString(self.passcode, forKey: self.key))
             stringForKeyQueue.async {
                 XCTAssertEqual(self.vanillaValet.string(forKey: self.key), self.passcode)
                 expectation.fulfill()
@@ -497,7 +497,7 @@ class ValetIntegrationTests: XCTestCase
 
         setStringQueue.async {
             let backgroundValet = Valet.valet(with: backgroundIdentifier, accessibility: .whenUnlocked)
-            XCTAssertTrue(backgroundValet.set(string: self.passcode, forKey: self.key))
+            XCTAssertTrue(backgroundValet.setString(self.passcode, forKey: self.key))
             stringForKeyQueue.async {
                 XCTAssertEqual(backgroundValet.string(forKey: self.key), self.passcode)
                 expectation.fulfill()
@@ -519,7 +519,7 @@ class ValetIntegrationTests: XCTestCase
     func test_removeObjectForKey_succeedsWhenKeyIsPresent()
     {
         allPermutations.forEach { valet in
-            XCTAssertTrue(valet.set(string: passcode, forKey: key))
+            XCTAssertTrue(valet.setString(passcode, forKey: key))
             XCTAssertTrue(valet.removeObject(forKey: key))
             XCTAssertNil(valet.string(forKey: key))
         }
@@ -528,7 +528,7 @@ class ValetIntegrationTests: XCTestCase
     func test_removeObjectForKey_isDistinctForDifferingAccessibility()
     {
         let differingAccessibility = Valet.valet(with: vanillaValet.identifier, accessibility: .whenUnlockedThisDeviceOnly)
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
 
         XCTAssertTrue(differingAccessibility.removeObject(forKey: key))
 
@@ -538,7 +538,7 @@ class ValetIntegrationTests: XCTestCase
     func test_removeObjectForKey_isDistinctForDifferingIdentifier()
     {
         let differingIdentifier = Valet.valet(with: Identifier(nonEmpty: "no")!, accessibility: vanillaValet.accessibility)
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
 
         XCTAssertTrue(differingIdentifier.removeObject(forKey: key))
 
@@ -551,8 +551,8 @@ class ValetIntegrationTests: XCTestCase
             return
         }
         
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
-        XCTAssertTrue(anotherFlavor.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
+        XCTAssertTrue(anotherFlavor.setString(passcode, forKey: key))
 
         XCTAssertTrue(vanillaValet.removeObject(forKey: key))
 
@@ -568,7 +568,7 @@ class ValetIntegrationTests: XCTestCase
             return
         }
 
-        vanillaValet.set(string: passcode, forKey: key)
+        vanillaValet.setString(passcode, forKey: key)
 
         guard let valetKeychainQuery = vanillaValet.keychainQuery else {
             XCTFail()
@@ -620,9 +620,9 @@ class ValetIntegrationTests: XCTestCase
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         migrationValet.removeAllObjects()
         
-        XCTAssertTrue(vanillaValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(vanillaValet.setString(passcode, forKey: key))
         let anotherValet = Valet.valet(with: Identifier(nonEmpty: #function)!, accessibility: .whenUnlocked)
-        XCTAssertTrue(anotherValet.set(string: passcode, forKey: key))
+        XCTAssertTrue(anotherValet.setString(passcode, forKey: key))
 
         let conflictingQuery = [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -666,7 +666,7 @@ class ValetIntegrationTests: XCTestCase
             return
         }
         
-        anotherFlavor.set(string: "foo", forKey: "bar")
+        anotherFlavor.setString("foo", forKey: "bar")
         _ = vanillaValet.migrateObjects(from: anotherFlavor, removeOnCompletion: false)
         _ = vanillaValet.allKeys()
         XCTAssertEqual("foo", vanillaValet.string(forKey: "bar"))
@@ -687,7 +687,7 @@ class ValetIntegrationTests: XCTestCase
         ]
 
         for (key, value) in keyValuePairs {
-            anotherFlavor.set(string: value, forKey: key)
+            anotherFlavor.setString(value, forKey: key)
         }
 
         XCTAssertEqual(vanillaValet.migrateObjects(from: anotherFlavor, removeOnCompletion: false), .success)
@@ -715,7 +715,7 @@ class ValetIntegrationTests: XCTestCase
         ]
 
         for (key, value) in keyValuePairs {
-            anotherFlavor.set(string: value, forKey: key)
+            anotherFlavor.setString(value, forKey: key)
         }
 
         XCTAssertEqual(vanillaValet.migrateObjects(from: anotherFlavor, removeOnCompletion: true), .success)
@@ -743,10 +743,10 @@ class ValetIntegrationTests: XCTestCase
         ]
 
         for (key, value) in keyValuePairs {
-            anotherFlavor.set(string: value, forKey: key)
+            anotherFlavor.setString(value, forKey: key)
         }
 
-        vanillaValet.set(string: "adrian", forKey: "yo")
+        vanillaValet.setString("adrian", forKey: "yo")
 
         XCTAssertEqual(1, vanillaValet.allKeys().count)
         XCTAssertEqual(keyValuePairs.count, anotherFlavor.allKeys().count)
@@ -771,7 +771,7 @@ class ValetIntegrationTests: XCTestCase
 
         let keyStringPairToMigrateMap = ["foo" : "bar", "testing" : "migration", "is" : "quite", "entertaining" : "if", "you" : "don't", "screw" : "up"]
         for (key, value) in keyStringPairToMigrateMap {
-            XCTAssertTrue(otherValet.set(string: value, forKey: key))
+            XCTAssertTrue(otherValet.setString(value, forKey: key))
         }
 
         XCTAssertTrue(vanillaValet.canAccessKeychain())

--- a/ValetTouchIDTest/ValetTouchIDTestViewController.swift
+++ b/ValetTouchIDTest/ValetTouchIDTestViewController.swift
@@ -45,7 +45,7 @@ final class ValetTouchIDTestViewController : UIViewController
     @IBAction func setOrUpdateItem(sender: UIResponder)
     {
         let stringToSet = "I am here! " + NSUUID().uuidString
-        let setOrUpdatedItem = singlePromptSecureEnclaveValet.set(string: stringToSet, forKey: username)
+        let setOrUpdatedItem = singlePromptSecureEnclaveValet.setString(stringToSet, forKey: username)
         updateTextView(messageComponents: #function, (setOrUpdatedItem ? "Success" : "Failure"))
     }
     


### PR DESCRIPTION
The goal of this PR is to no longer require that we specify `@objc`-specific method names by bringing our method names into [Apple's Swift guidelines for parameter names](https://swift.org/documentation/api-design-guidelines/#parameter-names).

This PR breaks out some of the changes in #198, and also brings the code into alignment with a744a370d77e8fa3a7c188cb3a5797c07a6ada36 (I thought I'd landed this change already 😬).