### PR TITLE
Fix control list vuln test by using persistent reference

### DIFF
--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -57,7 +57,7 @@ class ValetMacTests: XCTestCase
         XCTAssertTrue(valet.containsObject(forKey: vulnKey))
 
         // Obtain a reference to the vulnerable keychain entry.
-        query[kSecReturnRef as String] = true
+        query[kSecReturnPersistentRef as String] = true
         query[kSecReturnAttributes as String] = true
         var vulnerableEntryReference: CFTypeRef?
         XCTAssertEqual(SecItemCopyMatching(query as CFDictionary, &vulnerableEntryReference), errSecSuccess)
@@ -66,13 +66,13 @@ class ValetMacTests: XCTestCase
             XCTFail()
             return
         }
-        guard let vulnerableValueRef = vulnerableKeychainEntry[kSecValueRef as String] else {
+        guard let vulnerableValueRef = vulnerableKeychainEntry[kSecValuePersistentRef as String] else {
             XCTFail()
             return
         }
 
         let queryWithVulnerableReference = [
-            kSecValueRef as String: vulnerableValueRef
+            kSecValuePersistentRef as String: vulnerableValueRef
             ] as CFDictionary
         // Demonstrate that the item is accessible with the reference.
         XCTAssertEqual(SecItemCopyMatching(queryWithVulnerableReference, nil), errSecSuccess)
@@ -83,7 +83,7 @@ class ValetMacTests: XCTestCase
 
         // We should no longer be able to access the keychain item via the ref.
         let queryWithVulnerableReferenceAndAttributes = [
-            kSecValueRef as String: vulnerableValueRef,
+            kSecValuePersistentRef as String: vulnerableValueRef,
             kSecReturnAttributes as String: true
             ] as CFDictionary
         XCTAssertEqual(SecItemCopyMatching(queryWithVulnerableReferenceAndAttributes, nil), errSecItemNotFound)


### PR DESCRIPTION
I think this test broke in Catalina, ~but I can't be sure –– remember, this test requires a signed environment, so we can't test it in CI~. Update: this test does not require a signed environment and runs on every build.

For some reason, the reference we requested couldn't pull out the vulnerable value from the keychain anymore. I fixed this test by relying on a more-reliable persistent reference.