### PR TITLE
Remove an extraneous testEnvironmentIsSigned check in tests

### DIFF
--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -98,9 +98,6 @@ class ValetMacTests: XCTestCase
         guard #available(macOS 10.15, *) else {
             return
         }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
 
         let valet = Valet.valet(with: Identifier(nonEmpty: "PreCatalinaTest")!, accessibility: .afterFirstUnlock)
         var preCatalinaWriteQuery = valet.keychainQuery


### PR DESCRIPTION
I think I was too aggressive here. This isn't necessary.