### PR TITLE
Enable code coverage on master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ DerivedData
 .idea/
 .swiftpm/
 generated/
+*coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,19 @@ matrix:
     env: ACTION="swift-package";PLATFORMS="iOS_13,tvOS_13,macOS_10_15,watchOS_6";
   - osx_image: xcode11
     env: ACTION="xcode";PLATFORMS="iOS_13,tvOS_13,macOS_10_15,watchOS_6";
+    after_success:
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/iOS_13 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/tvOS_13 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/macOS_10_15 -t 5165deef-da9c-443d-90ea-bb0620bffe44
   - osx_image: xcode11
     env: ACTION="carthage"
 
   - osx_image: xcode10.2
     env: ACTION="xcode";PLATFORMS="iOS_12,tvOS_12,macOS_10_14,watchOS_5";
+    after_success:
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/iOS_12 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/tvOS_12 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/macOS_10_14 -t 5165deef-da9c-443d-90ea-bb0620bffe44
   - osx_image: xcode10.2
     env: ACTION="pod-lint";SWIFT_VERSION="5.0"
   - osx_image: xcode10.2
@@ -22,6 +30,10 @@ matrix:
 
   - osx_image: xcode9
     env: ACTION="xcode";PLATFORMS="iOS_11,tvOS_11,macOS_10_13,watchOS_4";
+    after_success:
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/iOS_11 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/tvOS_11 -t 5165deef-da9c-443d-90ea-bb0620bffe44
+    - bash <(curl -s https://codecov.io/bash) -J '^Valet$' -D .build/derivedData/macOS_10_13 -t 5165deef-da9c-443d-90ea-bb0620bffe44
   - osx_image: xcode9
     env: ACTION="pod-lint";SWIFT_VERSION="4.0"
   - osx_image: xcode9

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -111,6 +111,10 @@ enum Platform: String, CustomStringConvertible {
         }
     }
 
+    var derivedDataPath: String {
+        return ".build/derivedData/" + description
+    }
+
     var scheme: String {
         switch self {
         case .iOS_11,
@@ -243,8 +247,15 @@ for rawPlatform in rawPlatforms {
     if task.shouldUseLegacyBuildSystem {
         xcodeBuildArguments.append("-UseModernBuildSystem=0")
     }
+    let shouldTest = task.shouldTest(on: platform)
+    if shouldTest {
+        xcodeBuildArguments.append("-enableCodeCoverage")
+        xcodeBuildArguments.append("YES")
+        xcodeBuildArguments.append("-derivedDataPath")
+        xcodeBuildArguments.append(platform.derivedDataPath)
+    }
     xcodeBuildArguments.append("build")
-    if task.shouldTest(on: platform) {
+    if shouldTest {
         xcodeBuildArguments.append("test")
     }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
This PR is a follow-up to #201 and #202. This way we can compare coverage between `master` and `develop--4.0`.