### PR TITLE
[Valet 4.0] Use CaseIterable instead of allValues where possible

### DIFF
--- a/Sources/Valet/Accessibility.swift
+++ b/Sources/Valet/Accessibility.swift
@@ -22,7 +22,7 @@ import Foundation
 
 
 @objc(VALAccessibility)
-public enum Accessibility: Int, CustomStringConvertible, Equatable {
+public enum Accessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
     /// Valet data can only be accessed once the device has been unlocked after a restart. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
@@ -73,15 +73,4 @@ public enum Accessibility: Int, CustomStringConvertible, Equatable {
         return accessibilityAttribute as String
     }
 
-    // MARK: Internal
-
-    internal static func allValues() -> [Accessibility] {
-        [
-            .whenUnlocked,
-            .afterFirstUnlock,
-            .whenPasscodeSetThisDeviceOnly,
-            .whenUnlockedThisDeviceOnly,
-            .afterFirstUnlockThisDeviceOnly,
-        ]
-    }
 }

--- a/Sources/Valet/CloudAccessibility.swift
+++ b/Sources/Valet/CloudAccessibility.swift
@@ -22,7 +22,7 @@ import Foundation
 
 
 @objc(VALCloudAccessibility)
-public enum CloudAccessibility: Int, CustomStringConvertible, Equatable {
+public enum CloudAccessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
     /// Valet data can only be accessed once the device has been unlocked after a restart. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
@@ -49,12 +49,4 @@ public enum CloudAccessibility: Int, CustomStringConvertible, Equatable {
         accessibility.secAccessibilityAttribute
     }
 
-    // MARK: Internal
-
-    internal static func allValues() -> [CloudAccessibility] {
-        [
-            .whenUnlocked,
-            .afterFirstUnlock,
-        ]
-    }
 }

--- a/Sources/Valet/SecureEnclaveAccessControl.swift
+++ b/Sources/Valet/SecureEnclaveAccessControl.swift
@@ -24,19 +24,17 @@ import Foundation
 @objc(VALSecureEnclaveAccessControl)
 public enum SecureEnclaveAccessControl: Int, CustomStringConvertible, Equatable {
     /// Access to keychain elements requires user presence verification via Touch ID, Face ID, or device Passcode. Keychain elements are still accessible by Touch ID even if fingers are added or removed. Touch ID does not have to be available or enrolled.
-    /// - version: Available on iOS 8 or later, tvOS 8 or later, watchOS 2.0 or later, and macOS 10.11 or later.
     case userPresence = 1
     
     /// Access to keychain elements requires user presence verification via Face ID, or any finger enrolled in Touch ID. Keychain elements remain accessible via Face ID or Touch ID  after faces or fingers are added or removed. Face ID must be enabled with at least one face enrolled, or Touch ID must be available and at least one finger must be enrolled.
-    /// - version: Available on iOS 9 or later, tvOS 9 or later, watchOS 2.0 or later, and macOS 10.12.1 or later.
+    @available(macOS 10.12.1, *)
     case biometricAny
     
     /// Access to keychain elements requires user presence verification via the face currently enrolled in Face ID, or fingers currently enrolled in Touch ID. Previously written keychain elements become inaccessible when faces or fingers are added or removed. Face ID must be enabled with at least one face enrolled, or Touch ID must be available and at least one finger must be enrolled.
-    /// - version: Available on iOS 9 or later, tvOS 9 or later, watchOS 2.0 or later, and macOS 10.12.1 or later.
+    @available(macOS 10.12.1, *)
     case biometricCurrentSet
     
     /// Access to keychain elements requires user presence verification via device Passcode.
-    /// - version: Available on iOS 9 or later, tvOS 9 or later, watchOS 2.0 or later, and macOS 10.11 or later.
     case devicePasscode
     
     // MARK: CustomStringConvertible

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -601,26 +601,26 @@ internal extension Valet {
     // MARK: Permutations
 
     class func permutations(with identifier: Identifier, shared: Bool = false) -> [Valet] {
-        Accessibility.allValues().map { accessibility in
+        Accessibility.allCases.map { accessibility in
             shared ? .sharedAccessGroupValet(with: identifier, accessibility: accessibility) : .valet(with: identifier, accessibility: accessibility)
         }
     }
 
     class func iCloudPermutations(with identifier: Identifier, shared: Bool = false) -> [Valet] {
-        CloudAccessibility.allValues().map { cloudAccessibility in
+        CloudAccessibility.allCases.map { cloudAccessibility in
             shared ? .iCloudSharedAccessGroupValet(with: identifier, accessibility: cloudAccessibility) : .iCloudValet(with: identifier, accessibility: cloudAccessibility)
         }
     }
 
     #if os(macOS)
     class func permutations(withExplictlySet identifier: Identifier, shared: Bool = false) -> [Valet] {
-        Accessibility.allValues().map { accessibility in
+        Accessibility.allCases.map { accessibility in
             shared ? .sharedAccessGroupValet(withExplicitlySet: identifier, accessibility: accessibility) : .valet(withExplicitlySet: identifier, accessibility: accessibility)
         }
     }
 
     class func iCloudPermutations(withExplictlySet identifier: Identifier, shared: Bool = false) -> [Valet] {
-        CloudAccessibility.allValues().map { cloudAccessibility in
+        CloudAccessibility.allCases.map { cloudAccessibility in
             shared ? .iCloudSharedAccessGroupValet(withExplicitlySet: identifier, accessibility: cloudAccessibility) : .iCloudValet(withExplicitlySet: identifier, accessibility: cloudAccessibility)
         }
     }

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -277,7 +277,7 @@ class ValetMacTests: XCTestCase
         XCTAssertEqual(try valet.object(forKey: key), object)
     }
 
-    private let accessibilityValues = Accessibility.allValues()
+    private let accessibilityValues = Accessibility.allCases
 
 }
 #endif

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -124,7 +124,7 @@ class ValetIntegrationTests: XCTestCase
     func test_init_createsCorrectBackingService() {
         let identifier = ValetTests.identifier
 
-        Accessibility.allValues().forEach { accessibility in
+        Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.valet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.standard(identifier, .valet(accessibility)))
         }
@@ -133,7 +133,7 @@ class ValetIntegrationTests: XCTestCase
     func test_init_createsCorrectBackingService_sharedAccess() {
         let identifier = ValetTests.identifier
 
-        Accessibility.allValues().forEach { accessibility in
+        Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .valet(accessibility)))
         }
@@ -142,7 +142,7 @@ class ValetIntegrationTests: XCTestCase
     func test_init_createsCorrectBackingService_cloud() {
         let identifier = ValetTests.identifier
 
-        CloudAccessibility.allValues().forEach { accessibility in
+        CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.standard(identifier, .iCloud(accessibility)))
         }
@@ -151,7 +151,7 @@ class ValetIntegrationTests: XCTestCase
     func test_init_createsCorrectBackingService_cloudSharedAccess() {
         let identifier = ValetTests.identifier
 
-        CloudAccessibility.allValues().forEach { accessibility in
+        CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .iCloud(accessibility)))
         }

--- a/Tests/ValetTests/CloudAccessibilityTests.swift
+++ b/Tests/ValetTests/CloudAccessibilityTests.swift
@@ -23,13 +23,13 @@ import XCTest
 final class CloudAccessibilityTests: XCTestCase {
 
     func test_description_mirrorsAccessibilityCounterpartDescription() {
-        CloudAccessibility.allValues().forEach {
+        CloudAccessibility.allCases.forEach {
             XCTAssertEqual($0.description, $0.accessibility.description)
         }
     }
 
     func test_secAccessibilityAttribute_mirrorsAccessibilityCounterpartSecAccessibilityAttribute() {
-        CloudAccessibility.allValues().forEach {
+        CloudAccessibility.allCases.forEach {
             XCTAssertEqual($0.secAccessibilityAttribute, $0.accessibility.secAccessibilityAttribute)
         }
     }

--- a/Tests/ValetTests/ConfigurationTests.swift
+++ b/Tests/ValetTests/ConfigurationTests.swift
@@ -23,13 +23,13 @@ import XCTest
 final class ConfigurationTests: XCTestCase {
 
     func test_description_valet_mirrorsLegacyName() {
-        Accessibility.allValues().forEach {
+        Accessibility.allCases.forEach {
             XCTAssertEqual(Configuration.valet($0).description, "VALValet")
         }
     }
 
     func test_description_iCloud_mirrorsLegacyName() {
-        CloudAccessibility.allValues().forEach {
+        CloudAccessibility.allCases.forEach {
             XCTAssertEqual(Configuration.iCloud($0).description, "VALSynchronizableValet")
         }
     }
@@ -47,13 +47,13 @@ final class ConfigurationTests: XCTestCase {
     }
 
     func test_accessibility_valet_returnsPassedInAccessibility() {
-        Accessibility.allValues().forEach {
+        Accessibility.allCases.forEach {
             XCTAssertEqual(Configuration.valet($0).accessibility, $0)
         }
     }
 
     func test_accessibility_iCloud_returnsPassedInAccessibility() {
-        CloudAccessibility.allValues().forEach {
+        CloudAccessibility.allCases.forEach {
             XCTAssertEqual(Configuration.iCloud($0).accessibility, $0.accessibility)
         }
     }
@@ -71,13 +71,13 @@ final class ConfigurationTests: XCTestCase {
     }
 
     func test_prettyDescription_valet_isHumanReadable() {
-        Accessibility.allValues().forEach {
+        Accessibility.allCases.forEach {
             XCTAssertEqual(Configuration.valet($0).prettyDescription, "\($0) (Valet)")
         }
     }
 
     func test_prettyDescription_iCloud_isHumanReadable() {
-        CloudAccessibility.allValues().forEach {
+        CloudAccessibility.allCases.forEach {
             XCTAssertEqual(Configuration.iCloud($0).prettyDescription, "\($0) (iCloud)")
         }
     }

--- a/Tests/ValetTests/ValetTests.swift
+++ b/Tests/ValetTests/ValetTests.swift
@@ -34,7 +34,7 @@ class ValetTests: XCTestCase
     func test_init_createsCorrectBackingService() {
         let identifier = ValetTests.identifier
 
-        Accessibility.allValues().forEach { accessibility in
+        Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.valet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.standard(identifier, .valet(accessibility)))
         }
@@ -43,7 +43,7 @@ class ValetTests: XCTestCase
     func test_init_createsCorrectBackingService_sharedAccess() {
         let identifier = ValetTests.identifier
 
-        Accessibility.allValues().forEach { accessibility in
+        Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .valet(accessibility)))
         }
@@ -52,7 +52,7 @@ class ValetTests: XCTestCase
     func test_init_createsCorrectBackingService_cloud() {
         let identifier = ValetTests.identifier
 
-        CloudAccessibility.allValues().forEach { accessibility in
+        CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.standard(identifier, .iCloud(accessibility)))
         }
@@ -61,7 +61,7 @@ class ValetTests: XCTestCase
     func test_init_createsCorrectBackingService_cloudSharedAccess() {
         let identifier = ValetTests.identifier
 
-        CloudAccessibility.allValues().forEach { accessibility in
+        CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: accessibility).service
             XCTAssertEqual(backingService, Service.sharedAccessGroup(identifier, .iCloud(accessibility)))
         }


### PR DESCRIPTION
This PR follows up on https://github.com/square/Valet/pull/210#discussion_r369661195