### PR TITLE
Enable using kSecUseDataProtectionKeychain on macOS keychains prior to Catalina

### DIFF
--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -245,8 +245,7 @@ public final class Valet: NSObject, KeychainQueryConvertible {
     #if os(macOS)
     /// Migrates objects that were written to this Valet prior to macOS 10.15 to a format that can be read on macOS 10.15 and later. The new format is backwards compatible, allowing these values to be read on older operating systems.
     /// - returns: Whether the migration succeeded or failed.
-    /// - note: The keychain is not modified if a failure occurs. This method can only be called from macOS 10.15 or later.
-    @available(macOS 10.15, *)
+    /// - note: The keychain is not modified if a failure occurs.
     @objc(migrateObjectsFromPreCatalina)
     public func migrateObjectsFromPreCatalina() -> MigrationResult {
         var baseQuery = keychainQuery

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -106,7 +106,7 @@ class ValetMacTests: XCTestCase
     // MARK: Migration - PreCatalina
 
     func test_migrateObjectsFromPreCatalina_migratesDataWrittenPreCatalina() {
-        guard #available(macOS 10.15, *) else {
+        guard testEnvironmentIsSigned() else {
             return
         }
 


### PR DESCRIPTION
According to my tests in #214, it looks like `kSecUseDataProtectionKeychain` can be used on older macOS installs.

It seems possible that using `kSecUseDataProtectionKeychain` may obviate #140, since `kSecUseDataProtectionKeychain` seems to change how access control works. In the following screenshot, the left item was added to the keychain using `kSecUseDataProtectionKeychain = true`, and the right item was added using `kSecUseDataProtectionKeychain = false`:

![image](https://user-images.githubusercontent.com/139364/73125454-c3eec380-3f5b-11ea-85ec-c80dd8f193e6.png)

However, per #213, using `kSecUseDataProtectionKeychain` requires keychain sharing entitlements on macOS, so I've protected the test with `testEnvironmentIsSigned()`. Since our macOS CI environment isn't code-signed, CI can not tell us if this is working. However, given that my `kSecUseDataProtectionKeychain` tests in #214 failed on macOS 10.13 and 10.14 with `errSecMissingEntitlement`, that indicates to me that those keychains understand and respect `kSecUseDataProtectionKeychain` (otherwise we'd have gotten `errSecParam`).

If anyone has a pre-Catalina Mac install around and wants to help me test this, I'd be greatly appreciative. The test would involve using this branch of Valet in your application that has a Keychain Sharing entitlement on a pre-Catalina Mac, running `migrateObjectsFromPreCatalina()` on your Valet, and then trying to access the keychain. I think it'll just work, but, would be best to verify.