### PR TITLE
Require that App ID Prefix be explicitly passed into Shared Access Group Valets

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ In addition to allowing the storage of strings, Valet allows the storage of `Dat
 ### Sharing Secrets Among Multiple Applications
 
 ```swift
-let mySharedValet = Valet.sharedAccessGroupValet(with: Identifier(nonEmpty: "Druidia")!, accessibility: .whenUnlocked)
+let mySharedValet = Valet.sharedAccessGroupValet(with: Identifier(nonEmpty: "AppID12345.Druidia")!, accessibility: .whenUnlocked)
 ```
 
 ```objc
-VALValet *const mySharedValet = [VALValet valetWithSharedAccessGroupIdentifier:@"Druidia" accessibility:VALAccessibilityWhenUnlocked];
+VALValet *const mySharedValet = [VALValet valetWithSharedAccessGroupIdentifier:@"AppID12345.Druidia" accessibility:VALAccessibilityWhenUnlocked];
 ```
 
-This instance can be used to store and retrieve data securely across any app written by the same developer with the value `Druidia` under the `keychain-access-groups` key in the app’s `Entitlements` file, when the device is unlocked. Note that `myValet` and `mySharedValet` can not read or modify one another’s values because the two Valets were created with different initializers. All Valet types can share secrets across applications written by the same developer by using the `sharedAccessGroupValet` initializer.
+This instance can be used to store and retrieve data securely across any app written by the same developer that has `AppID12345.Druidia` (or `$(AppIdentifierPrefix)Druidia`) set as a value for the `keychain-access-groups` key in the app’s `Entitlements`, where `AppID12345` is the application’s [App ID prefix](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps#2974920). This Valet is accessible when the device is unlocked. Note that `myValet` and `mySharedValet` can not read or modify one another’s values because the two Valets were created with different initializers. All Valet types can share secrets across applications written by the same developer by using the `sharedAccessGroupValet` initializer.
 
 ### Sharing Secrets Across Devices with iCloud
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ In addition to allowing the storage of strings, Valet allows the storage of `Dat
 ### Sharing Secrets Among Multiple Applications
 
 ```swift
-let mySharedValet = Valet.sharedAccessGroupValet(with: Identifier(nonEmpty: "AppID12345.Druidia")!, accessibility: .whenUnlocked)
+let mySharedValet = Valet.sharedAccessGroupValet(with: SharedAccessGroupIdentifier(appIDPrefix: "AppID12345", nonEmptyGroup: "Druidia")!, accessibility: .whenUnlocked)
 ```
 
 ```objc
-VALValet *const mySharedValet = [VALValet valetWithSharedAccessGroupIdentifier:@"AppID12345.Druidia" accessibility:VALAccessibilityWhenUnlocked];
+VALValet *const mySharedValet = [VALValet sharedAccessGroupValetWithAppIDPrefix:@"AppID12345" sharedAccessGroupIdentifier:@"Druidia" accessibility:VALAccessibilityWhenUnlocked];
 ```
 
 This instance can be used to store and retrieve data securely across any app written by the same developer that has `AppID12345.Druidia` (or `$(AppIdentifierPrefix)Druidia`) set as a value for the `keychain-access-groups` key in the app’s `Entitlements`, where `AppID12345` is the application’s [App ID prefix](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps#2974920). This Valet is accessible when the device is unlocked. Note that `myValet` and `mySharedValet` can not read or modify one another’s values because the two Valets were created with different initializers. All Valet types can share secrets across applications written by the same developer by using the `sharedAccessGroupValet` initializer.

--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -23,7 +23,7 @@ import Foundation
 
 internal enum Service: CustomStringConvertible, Equatable {
     case standard(Identifier, Configuration)
-    case sharedAccessGroup(Identifier, Configuration)
+    case sharedAccessGroup(SharedAccessGroupIdentifier, Configuration)
 
     #if os(macOS)
     case standardOverride(service: Identifier, Configuration)
@@ -48,7 +48,11 @@ internal enum Service: CustomStringConvertible, Equatable {
         "VAL_\(configuration.description)_initWithIdentifier:accessibility:_\(identifier)_\(accessibilityDescription)"
     }
 
-    internal static func sharedAccessGroup(with configuration: Configuration, identifier: Identifier, accessibilityDescription: String) -> String {
+    internal static func sharedAccessGroup(with configuration: Configuration, identifier: SharedAccessGroupIdentifier, accessibilityDescription: String) -> String {
+        "VAL_\(configuration.description)_initWithSharedAccessGroupIdentifier:accessibility:_\(identifier.groupIdentifier)_\(accessibilityDescription)"
+    }
+
+    internal static func sharedAccessGroup(with configuration: Configuration, explicitlySetIdentifier identifier: Identifier, accessibilityDescription: String) -> String {
         "VAL_\(configuration.description)_initWithSharedAccessGroupIdentifier:accessibility:_\(identifier)_\(accessibilityDescription)"
     }
 

--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -54,7 +54,7 @@ internal enum Service: CustomStringConvertible, Equatable {
 
     // MARK: Internal Methods
     
-    internal func generateBaseQuery() throws -> [String : AnyHashable] {
+    internal func generateBaseQuery() -> [String : AnyHashable] {
         var baseQuery: [String : AnyHashable] = [
             kSecClass as String : kSecClassGenericPassword as String,
             kSecAttrService as String : secService,
@@ -70,15 +70,7 @@ internal enum Service: CustomStringConvertible, Equatable {
             configuration = desiredConfiguration
             
         case let .sharedAccessGroup(identifier, desiredConfiguration):
-            guard let sharedAccessGroupPrefix = SecItem.sharedAccessGroupPrefix else {
-                throw KeychainError.couldNotAccessKeychain
-            }
-            if identifier.description.hasPrefix("\(sharedAccessGroupPrefix).") {
-                // The Bundle Seed ID was passed in as a prefix to the identifier.
-                baseQuery[kSecAttrAccessGroup as String] = identifier.description
-            } else {
-                baseQuery[kSecAttrAccessGroup as String] = "\(sharedAccessGroupPrefix).\(identifier.description)"
-            }
+            baseQuery[kSecAttrAccessGroup as String] = identifier.description
             configuration = desiredConfiguration
 
         #if os(macOS)
@@ -86,15 +78,7 @@ internal enum Service: CustomStringConvertible, Equatable {
             configuration = desiredConfiguration
 
         case let .sharedAccessGroupOverride(identifier, desiredConfiguration):
-            guard let sharedAccessGroupPrefix = SecItem.sharedAccessGroupPrefix else {
-                throw KeychainError.couldNotAccessKeychain
-            }
-            if identifier.description.hasPrefix("\(sharedAccessGroupPrefix).") {
-                // The Bundle Seed ID was passed in as a prefix to the identifier.
-                baseQuery[kSecAttrAccessGroup as String] = identifier.description
-            } else {
-                baseQuery[kSecAttrAccessGroup as String] = "\(sharedAccessGroupPrefix).\(identifier.description)"
-            }
+            baseQuery[kSecAttrAccessGroup as String] = identifier.description
             configuration = desiredConfiguration
         #endif
         }

--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -27,7 +27,7 @@ internal enum Service: CustomStringConvertible, Equatable {
 
     #if os(macOS)
     case standardOverride(service: Identifier, Configuration)
-    case sharedAccessGroupOverride(service: Identifier, Configuration)
+    case sharedAccessGroupOverride(service: SharedAccessGroupIdentifier, Configuration)
     #endif
 
     // MARK: Equatable
@@ -114,9 +114,10 @@ internal enum Service: CustomStringConvertible, Equatable {
         case let .sharedAccessGroup(identifier, configuration):
             service = Service.sharedAccessGroup(with: configuration, identifier: identifier, accessibilityDescription: configuration.accessibility.description)
         #if os(macOS)
-        case let .standardOverride(identifier, _),
-             let .sharedAccessGroupOverride(identifier, _):
+        case let .standardOverride(identifier, _):
             service = identifier.description
+        case let .sharedAccessGroupOverride(identifier, _):
+            service = identifier.groupIdentifier
         #endif
         }
 

--- a/Sources/Valet/SecureEnclave.swift
+++ b/Sources/Valet/SecureEnclave.swift
@@ -25,26 +25,24 @@ public final class SecureEnclave {
         
     // MARK: Internal Methods
 
-    /// - Parameters:
-    ///   - service: The service of the keychain slice we want to check if we can access.
-    ///   - identifier: A non-empty identifier that scopes the slice of keychain we want to access.
+    /// - Parameter service: The service of the keychain slice we want to check if we can access.
     /// - Returns: `true` if the keychain is accessible for reading and writing, `false` otherwise.
     /// - Note: Determined by writing a value to the keychain and then reading it back out.
-    internal static func canAccessKeychain(with service: Service, identifier: Identifier) -> Bool {
+    internal static func canAccessKeychain(with service: Service) -> Bool {
         // To avoid prompting the user for Touch ID or passcode, create a Valet with our identifier and accessibility and ask it if it can access the keychain.
         let noPromptValet: Valet
         switch service {
         #if os(macOS)
-        case .standardOverride:
-            fallthrough
+        case let .standardOverride(identifier, _):
+            noPromptValet = .valet(with: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         #endif
-        case .standard:
+        case let .standard(identifier, _):
             noPromptValet = .valet(with: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         #if os(macOS)
-        case .sharedAccessGroupOverride:
-            fallthrough
+        case let .sharedAccessGroupOverride(identifier, _):
+            noPromptValet = .sharedAccessGroupValet(withExplicitlySet: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         #endif
-        case .sharedAccessGroup:
+        case let .sharedAccessGroup(identifier, _):
             noPromptValet = .sharedAccessGroupValet(with: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         }
         

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -95,7 +95,7 @@ public final class SecureEnclaveValet: NSObject {
         self.identifier = identifier
         self.service = service
         self.accessControl = accessControl
-        _keychainQuery = try? service.generateBaseQuery()
+        baseKeychainQuery = service.generateBaseQuery()
     }
     
     // MARK: Hashable
@@ -126,7 +126,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
-            try SecureEnclave.setObject(object, forKey: key, options: try keychainQuery())
+            try SecureEnclave.setObject(object, forKey: key, options: baseKeychainQuery)
         }
     }
 
@@ -138,7 +138,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func object(forKey key: String, withPrompt userPrompt: String) throws -> Data {
         try execute(in: lock) {
-            try SecureEnclave.object(forKey: key, withPrompt: userPrompt, options: try keychainQuery())
+            try SecureEnclave.object(forKey: key, withPrompt: userPrompt, options: baseKeychainQuery)
         }
     }
 
@@ -148,7 +148,7 @@ public final class SecureEnclaveValet: NSObject {
     /// - Note: Will never prompt the user for Face ID, Touch ID, or password.
     public func containsObject(forKey key: String) throws -> Bool {
         try execute(in: lock) {
-            try SecureEnclave.containsObject(forKey: key, options: try keychainQuery())
+            try SecureEnclave.containsObject(forKey: key, options: baseKeychainQuery)
         }
     }
 
@@ -159,7 +159,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {
-            try SecureEnclave.setString(string, forKey: key, options: try keychainQuery())
+            try SecureEnclave.setString(string, forKey: key, options: baseKeychainQuery)
         }
     }
 
@@ -171,7 +171,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func string(forKey key: String, withPrompt userPrompt: String) throws -> String {
         try execute(in: lock) {
-            try SecureEnclave.string(forKey: key, withPrompt: userPrompt, options: try keychainQuery())
+            try SecureEnclave.string(forKey: key, withPrompt: userPrompt, options: baseKeychainQuery)
         }
     }
     
@@ -181,7 +181,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func removeObject(forKey key: String) throws {
         try execute(in: lock) {
-            try Keychain.removeObject(forKey: key, options: try keychainQuery())
+            try Keychain.removeObject(forKey: key, options: baseKeychainQuery)
         }
     }
     
@@ -190,7 +190,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func removeAllObjects() throws {
         try execute(in: lock) {
-            try Keychain.removeAllObjects(matching: try keychainQuery())
+            try Keychain.removeAllObjects(matching: baseKeychainQuery)
         }
     }
     
@@ -203,7 +203,7 @@ public final class SecureEnclaveValet: NSObject {
     @objc
     public func migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool) throws {
         try execute(in: lock) {
-            try Keychain.migrateObjects(matching: query, into: try keychainQuery(), removeOnCompletion: removeOnCompletion)
+            try Keychain.migrateObjects(matching: query, into: baseKeychainQuery, removeOnCompletion: removeOnCompletion)
         }
     }
     
@@ -215,7 +215,7 @@ public final class SecureEnclaveValet: NSObject {
     /// - Note: The keychain is not modified if an error is thrown.
     @objc
     public func migrateObjects(from valet: Valet, removeOnCompletion: Bool) throws {
-        try migrateObjects(matching: try valet.keychainQuery(), removeOnCompletion: removeOnCompletion)
+        try migrateObjects(matching: valet.baseKeychainQuery, removeOnCompletion: removeOnCompletion)
     }
 
     // MARK: Internal Properties
@@ -225,19 +225,8 @@ public final class SecureEnclaveValet: NSObject {
     // MARK: Private Properties
 
     private let lock = NSLock()
-    private var _keychainQuery: [String : AnyHashable]?
+    private let baseKeychainQuery: [String : AnyHashable]
 
-    // MARK: Private Methods
-
-    private func keychainQuery() throws -> [String : AnyHashable] {
-        if let keychainQuery = _keychainQuery {
-            return keychainQuery
-        } else {
-            let keychainQuery = try service.generateBaseQuery()
-            _keychainQuery = keychainQuery
-            return keychainQuery
-        }
-    }
 }
 
 

--- a/Sources/Valet/SharedAccessGroupIdentifier.swift
+++ b/Sources/Valet/SharedAccessGroupIdentifier.swift
@@ -1,0 +1,57 @@
+//
+//  SharedAccessGroupIdentifier.swift
+//  Valet
+//
+//  Created by Dan Federman on 2/25/20.
+//  Copyright © 2020 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+
+public struct SharedAccessGroupIdentifier: CustomStringConvertible {
+
+    // MARK: Initialization
+
+    /// A representation of a shared access group identifier.
+    /// - Parameters:
+    ///   - appIDPrefix: The application's App ID prefix. This string can be found by inspecting the application's provisioning profile, or viewing the application's App ID Configuration on developer.apple.com. This string must not be empty.
+    ///   - groupIdentifier: An identifier that cooresponds to a value in keychain-access-groups in the application's Entitlements file. This string must not be empty.
+    /// - SeeAlso: https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
+    public init?(appIDPrefix: String, nonEmptyGroup groupIdentifier: String?) {
+        guard !appIDPrefix.isEmpty, let groupIdentifier = groupIdentifier, !groupIdentifier.isEmpty else {
+            return nil
+        }
+
+        self.appIDPrefix = appIDPrefix
+        self.groupIdentifier = groupIdentifier
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return appIDPrefix + "." + groupIdentifier
+    }
+
+    // MARK: Internal Properties
+
+    internal let appIDPrefix: String
+    internal let groupIdentifier: String
+
+    internal var asIdentifier: Identifier {
+        // It is safe to force unwrap because we've already validated that our description is non-empty.
+        Identifier(nonEmpty: description)!
+    }
+}

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -48,10 +48,10 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     }
 
     /// - Parameters:
-    ///   - identifier: A non-empty string that must correspond with the value for keychain-access-groups in your Entitlements file.
+    ///   - identifier: A non-empty identifier that must correspond with the value for keychain-access-groups in your Entitlements file.
     ///   - accessControl: The desired access control for the SinglePromptSecureEnclaveValet.
     /// - Returns: A SinglePromptSecureEnclaveValet that reads/writes keychain elements that can be shared across applications written by the same development team.
-    public class func sharedAccessGroupValet(with identifier: Identifier, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet {
+    public class func sharedAccessGroupValet(with identifier: SharedAccessGroupIdentifier, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet {
         let key = Service.sharedAccessGroup(identifier, .singlePromptSecureEnclave(accessControl)).description as NSString
         if let existingValet = identifierToValetMap.object(forKey: key) {
             return existingValet
@@ -88,10 +88,10 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
             accessControl: accessControl)
     }
     
-    private convenience init(sharedAccess identifier: Identifier, accessControl: SecureEnclaveAccessControl) {
+    private convenience init(sharedAccess groupIdentifier: SharedAccessGroupIdentifier, accessControl: SecureEnclaveAccessControl) {
         self.init(
-            identifier: identifier,
-            service: .sharedAccessGroup(identifier, .singlePromptSecureEnclave(accessControl)),
+            identifier: groupIdentifier.asIdentifier,
+            service: .sharedAccessGroup(groupIdentifier, .singlePromptSecureEnclave(accessControl)),
             accessControl: accessControl)
     }
 
@@ -120,7 +120,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     /// - Note: Determined by writing a value to the keychain and then reading it back out. Will never prompt the user for Face ID, Touch ID, or password.
     @objc
     public func canAccessKeychain() -> Bool {
-        SecureEnclave.canAccessKeychain(with: service, identifier: identifier)
+        SecureEnclave.canAccessKeychain(with: service)
     }
 
     /// - Parameters:
@@ -290,12 +290,14 @@ extension SinglePromptSecureEnclaveValet {
     }
 
     /// - Parameters:
-    ///   - identifier: A non-empty string that must correspond with the value for keychain-access-groups in your Entitlements file.
+    ///   - appIDPrefix: The application's App ID prefix. This string can be found by inspecting the application's provisioning profile, or viewing the application's App ID Configuration on developer.apple.com. This string must not be empty.
+    ///   - identifier: An identifier that cooresponds to a value in keychain-access-groups in the application's Entitlements file. This string must not be empty.
     ///   - accessControl: The desired access control for the SinglePromptSecureEnclaveValet.
     /// - Returns: A SinglePromptSecureEnclaveValet that reads/writes keychain elements that can be shared across applications written by the same development team.
-    @objc(sharedAccessGroupValetWithIdentifier:accessControl:)
-    public class func 🚫swift_sharedAccessGroupValet(with identifier: String, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet? {
-        guard let identifier = Identifier(nonEmpty: identifier) else {
+    /// - SeeAlso: https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
+    @objc(sharedAccessGroupValetWithAppIDPrefix:sharedAccessGroupIdentifier:accessControl:)
+    public class func 🚫swift_sharedAccessGroupValet(appIDPrefix: String, nonEmptyIdentifier identifier: String, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet? {
+        guard let identifier = SharedAccessGroupIdentifier(appIDPrefix: appIDPrefix, nonEmptyGroup: identifier) else {
             return nil
         }
         return sharedAccessGroupValet(with: identifier, accessControl: accessControl)

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
@@ -47,7 +47,7 @@ extension CloudIntegrationTests {
             return
         }
 
-        try Valet.iCloudCurrentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier, shared: true).forEach { permutation, legacyValet in
+        try Valet.iCloudCurrentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)
 
             XCTAssertNotNil(legacyValet.string(forKey: key))

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -37,7 +37,7 @@ internal extension Valet {
             return identifier.description
         #if os(macOS)
         case let .sharedAccessGroupOverride(identifier, _):
-            return identifier.description
+            return identifier.groupIdentifier
         case let .standardOverride(identifier, _):
             return identifier.description
         #endif

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -30,7 +30,18 @@ import XCTest
 internal extension Valet {
 
     var legacyIdentifier: String {
-        return identifier.description
+        switch service {
+        case let .sharedAccessGroup(sharedAccessGroupIdentifier, _):
+            return sharedAccessGroupIdentifier.groupIdentifier
+        case let .standard(identifier, _):
+            return identifier.description
+        #if os(macOS)
+        case let .sharedAccessGroupOverride(identifier, _):
+            return identifier.description
+        case let .standardOverride(identifier, _):
+            return identifier.description
+        #endif
+        }
     }
 
     var legacyAccessibility: VALLegacyAccessibility {
@@ -77,14 +88,26 @@ internal extension Valet {
 
     // MARK: Permutations
 
-    class func currentAndLegacyPermutations(with identifier: Identifier, shared: Bool = false) -> [(Valet, VALLegacyValet)] {
-        permutations(with: identifier, shared: shared).map {
+    class func currentAndLegacyPermutations(with identifier: Identifier) -> [(Valet, VALLegacyValet)] {
+        permutations(with: identifier).map {
             ($0, $0.legacyValet)
         }
     }
 
-    class func iCloudCurrentAndLegacyPermutations(with identifier: Identifier, shared: Bool = false) -> [(Valet, VALSynchronizableValet)] {
-        iCloudPermutations(with: identifier, shared: shared).map {
+    class func currentAndLegacyPermutations(with identifier: SharedAccessGroupIdentifier) -> [(Valet, VALLegacyValet)] {
+        permutations(with: identifier).map {
+            ($0, $0.legacyValet)
+        }
+    }
+
+    class func iCloudCurrentAndLegacyPermutations(with identifier: Identifier) -> [(Valet, VALSynchronizableValet)] {
+        iCloudPermutations(with: identifier).map {
+            ($0, $0.legacyValet as! VALSynchronizableValet)
+        }
+    }
+
+    class func iCloudCurrentAndLegacyPermutations(with identifier: SharedAccessGroupIdentifier) -> [(Valet, VALSynchronizableValet)] {
+        iCloudPermutations(with: identifier).map {
             ($0, $0.legacyValet as! VALSynchronizableValet)
         }
     }
@@ -114,7 +137,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
         guard testEnvironmentIsSigned() else {
             return
         }
-        try Valet.currentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier, shared: true).forEach { permutation, legacyValet in
+        try Valet.currentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)
 
             XCTAssertNotNil(legacyValet.string(forKey: key))
@@ -149,7 +172,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
         guard testEnvironmentIsSigned() else {
             return
         }
-        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.description, accessibility: .always)!
+        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.groupIdentifier, accessibility: .always)!
         alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
 
         let valet = Valet.sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessibility: .afterFirstUnlock)
@@ -161,7 +184,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
         guard testEnvironmentIsSigned() else {
             return
         }
-        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.description, accessibility: .alwaysThisDeviceOnly)!
+        let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.groupIdentifier, accessibility: .alwaysThisDeviceOnly)!
         alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
 
         let valet = Valet.sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessibility: .afterFirstUnlockThisDeviceOnly)

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -30,7 +30,7 @@ class CloudIntegrationTests: XCTestCase
     static let accessibility = CloudAccessibility.whenUnlocked
     var allPermutations: [Valet] {
         return (testEnvironmentIsSigned()
-            ? Valet.iCloudPermutations(with: CloudIntegrationTests.identifier) + Valet.iCloudPermutations(with: ValetIntegrationTests.identifier, shared: true)
+            ? Valet.iCloudPermutations(with: CloudIntegrationTests.identifier.asIdentifier) + Valet.iCloudPermutations(with: CloudIntegrationTests.identifier)
             : [])
     }
     let key = "key"

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -145,7 +145,7 @@ class ValetMacTests: XCTestCase
             try $0.removeAllObjects()
         }
 
-        let explicitlySetSharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
+        let explicitlySetSharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-macOS-Test-Host-App")!
         try Valet.permutations(withExplictlySet: explicitlySetSharedAccessGroupIdentifier, shared: true).forEach {
             XCTAssertTrue($0.canAccessKeychain())
 
@@ -182,7 +182,7 @@ class ValetMacTests: XCTestCase
             try $0.removeAllObjects()
         }
 
-        let explicitlySetSharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
+        let explicitlySetSharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-macOS-Test-Host-App")!
         try Valet.permutations(withExplictlySet: explicitlySetSharedAccessGroupIdentifier, shared: true).forEach {
             try $0.setString(passcode, forKey: key)
             XCTAssertEqual(try $0.string(forKey: key), passcode)

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -36,7 +36,7 @@ class ValetMacTests: XCTestCase
         let vulnValue = "Secret"
         try valet.removeObject(forKey: vulnKey)
 
-        var query = try valet.keychainQuery()
+        var query = valet.baseKeychainQuery
         query[kSecAttrAccount as String] = vulnKey
 
         var accessList: SecAccess?
@@ -106,24 +106,24 @@ class ValetMacTests: XCTestCase
 
     func test_withExplicitlySet_assignsExplicitIdentifier() throws {
         let explicitlySetIdentifier = Identifier(nonEmpty: #function)!
-        try Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: false).forEach {
-            XCTAssertEqual(try $0.keychainQuery()[kSecAttrService as String], explicitlySetIdentifier.description)
+        Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: false).forEach {
+            XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
         }
 
-        try Valet.iCloudPermutations(withExplictlySet: explicitlySetIdentifier, shared: false).forEach {
-            XCTAssertEqual(try $0.keychainQuery()[kSecAttrService as String], explicitlySetIdentifier.description)
+        Valet.iCloudPermutations(withExplictlySet: explicitlySetIdentifier, shared: false).forEach {
+            XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
         }
 
         guard testEnvironmentIsSigned() else {
             return
         }
 
-        try Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: true).forEach {
-            XCTAssertEqual(try $0.keychainQuery()[kSecAttrService as String], explicitlySetIdentifier.description)
+        Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: true).forEach {
+            XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
         }
 
-        try Valet.iCloudPermutations(withExplictlySet: explicitlySetIdentifier, shared: true).forEach {
-            XCTAssertEqual(try $0.keychainQuery()[kSecAttrService as String], explicitlySetIdentifier.description)
+        Valet.iCloudPermutations(withExplictlySet: explicitlySetIdentifier, shared: true).forEach {
+            XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
         }
     }
 
@@ -258,7 +258,7 @@ class ValetMacTests: XCTestCase
         }
 
         let valet = Valet.valet(with: Identifier(nonEmpty: "PreCatalinaTest")!, accessibility: .afterFirstUnlock)
-        var preCatalinaWriteQuery = try valet.keychainQuery()
+        var preCatalinaWriteQuery = valet.baseKeychainQuery
         preCatalinaWriteQuery[kSecUseDataProtectionKeychain as String] = nil
 
         let key = "PreCatalinaKey"

--- a/Tests/ValetIntegrationTests/SecItemTests.swift
+++ b/Tests/ValetIntegrationTests/SecItemTests.swift
@@ -25,23 +25,5 @@ import XCTest
 
 
 class SecItemTests: XCTestCase {
-
-    func test_sharedAccessGroupPrefix_findsPrefix() {
-        #if os(watchOS) || os(tvOS) || os(iOS)
-            // CocoaPods app host DSL does not provide ability to edit the app host settings such
-            // the `DEVELOPER TEAM` so for now skip this assertion.
-            #if !COCOAPODS
-                XCTAssertEqual(SecItem.sharedAccessGroupPrefix, "9XUJ7M53NG")
-            #endif
-        #elseif os(macOS)
-            guard testEnvironmentIsSigned() else {
-                return
-            }
-            XCTAssertEqual(SecItem.sharedAccessGroupPrefix, "9XUJ7M53NG")
-        #else
-            // Currently unsupported build configuration. This next line will compile-time error.
-            doNotCommentOutThisLine()
-        #endif
-    }
     
 }

--- a/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
@@ -95,22 +95,9 @@ class SecureEnclaveIntegrationTests: XCTestCase
         guard testEnvironmentIsSigned() else {
             return
         }
-        
-        let sharedAccessGroupIdentifier: Identifier
-        #if os(iOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-iOS-Test-Host-App")!
-        #elseif os(macOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
-        #elseif os(tvOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-tvOS-Test-Host-App")!
-        #elseif os(watchOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension")!
-        #else
-            XCTFail()
-        #endif
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
-            return .sharedAccessGroupValet(with: sharedAccessGroupIdentifier, accessControl: accessControl)
+            return .sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessControl: accessControl)
         }
         
         for permutation in permutations {

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -151,19 +151,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
             return
         }
         
-        let sharedAccessGroupIdentifier: Identifier
-        #if os(iOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-iOS-Test-Host-App")!
-        #elseif os(macOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
-        #elseif os(tvOS)
-            sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-tvOS-Test-Host-App")!
-        #else
-            XCTFail()
-        #endif
-
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
-            return .sharedAccessGroupValet(with: sharedAccessGroupIdentifier, accessControl: accessControl)
+            return .sharedAccessGroupValet(with: Valet.sharedAccessGroupIdentifier, accessControl: accessControl)
         }
 
         for permutation in permutations {

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -63,13 +63,13 @@ internal extension Valet {
     static var sharedAccessGroupIdentifier: Identifier = {
         let sharedAccessGroupIdentifier: Identifier
         #if os(iOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-iOS-Test-Host-App")!
+        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-iOS-Test-Host-App")!
         #elseif os(macOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-macOS-Test-Host-App")!
+        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-macOS-Test-Host-App")!
         #elseif os(tvOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.Valet-tvOS-Test-Host-App")!
+        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-tvOS-Test-Host-App")!
         #elseif os(watchOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension")!
+        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension")!
         #else
         XCTFail()
         #endif

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -60,20 +60,18 @@ internal extension Valet {
 
     // MARK: Shared Access Group
 
-    static var sharedAccessGroupIdentifier: Identifier = {
-        let sharedAccessGroupIdentifier: Identifier
+    static var sharedAccessGroupIdentifier: SharedAccessGroupIdentifier = {
         #if os(iOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-iOS-Test-Host-App")!
+        return SharedAccessGroupIdentifier(appIDPrefix: "9XUJ7M53NG", nonEmptyGroup: "com.squareup.Valet-iOS-Test-Host-App")!
         #elseif os(macOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-macOS-Test-Host-App")!
+        return SharedAccessGroupIdentifier(appIDPrefix: "9XUJ7M53NG", nonEmptyGroup: "com.squareup.Valet-macOS-Test-Host-App")!
         #elseif os(tvOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.Valet-tvOS-Test-Host-App")!
+        return SharedAccessGroupIdentifier(appIDPrefix: "9XUJ7M53NG", nonEmptyGroup: "com.squareup.Valet-tvOS-Test-Host-App")!
         #elseif os(watchOS)
-        sharedAccessGroupIdentifier = Identifier(nonEmpty: "9XUJ7M53NG.com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension")!
+        return SharedAccessGroupIdentifier(appIDPrefix: "9XUJ7M53NG", nonEmptyGroup: "com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension")!
         #else
         XCTFail()
         #endif
-        return sharedAccessGroupIdentifier
     }()
 
 }
@@ -81,15 +79,15 @@ internal extension Valet {
 
 class ValetIntegrationTests: XCTestCase
 {
-    static let identifier = Valet.sharedAccessGroupIdentifier
+    static let sharedAccessGroupIdentifier = Valet.sharedAccessGroupIdentifier
     var allPermutations: [Valet] {
-        return Valet.permutations(with: ValetIntegrationTests.identifier)
-            + (testEnvironmentIsSigned() ? Valet.permutations(with: ValetIntegrationTests.identifier, shared: true) : [])
+        return Valet.permutations(with: ValetIntegrationTests.sharedAccessGroupIdentifier.asIdentifier)
+            + (testEnvironmentIsSigned() ? Valet.permutations(with: ValetIntegrationTests.sharedAccessGroupIdentifier) : [])
     }
 
-    let vanillaValet = Valet.valet(with: identifier, accessibility: .whenUnlocked)
+    let vanillaValet = Valet.valet(with: sharedAccessGroupIdentifier.asIdentifier, accessibility: .whenUnlocked)
     // FIXME: Need a different flavor (Synchronizable must be tested in a signed environment)
-    let anotherFlavor = Valet.iCloudValet(with: identifier, accessibility: .whenUnlocked)
+    let anotherFlavor = Valet.iCloudValet(with: sharedAccessGroupIdentifier.asIdentifier, accessibility: .whenUnlocked)
 
     let key = "key"
     let passcode = "topsecret"
@@ -131,7 +129,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_sharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service
@@ -149,7 +147,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_cloudSharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: accessibility).service
@@ -172,7 +170,7 @@ class ValetIntegrationTests: XCTestCase
             return
         }
 
-        Valet.permutations(with: Valet.sharedAccessGroupIdentifier, shared: true).forEach { permutation in
+        Valet.permutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation in
             XCTAssertTrue(permutation.canAccessKeychain(), "\(permutation) could not access keychain.")
         }
     }

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -309,7 +309,7 @@ class ValetIntegrationTests: XCTestCase
     #if !os(macOS)
     func test_objectForKey_canReadItemsWithout_kSecUseDataProtectionKeychain_when_kSecUseDataProtectionKeychain_isSetToTrueInKeychainQuery() throws {
         let valet = Valet.valet(with: Identifier(nonEmpty: "DataProtectionTest")!, accessibility: .afterFirstUnlock)
-        var dataProtectionWriteQuery = try valet.keychainQuery()
+        var dataProtectionWriteQuery = valet.baseKeychainQuery
         if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) {
             dataProtectionWriteQuery[kSecUseDataProtectionKeychain as String] = nil
         }
@@ -641,7 +641,7 @@ class ValetIntegrationTests: XCTestCase
 
         try vanillaValet.setString(passcode, forKey: key)
 
-        let valetKeychainQuery = try vanillaValet.keychainQuery()
+        let valetKeychainQuery = vanillaValet.baseKeychainQuery
 
         // Test for base query success.
         try anotherFlavor.migrateObjects(matching: valetKeychainQuery, removeOnCompletion: false)
@@ -680,7 +680,7 @@ class ValetIntegrationTests: XCTestCase
             XCTAssertEqual(error as? KeychainError, .itemNotFound)
         }
 
-        let valetKeychainQuery = try vanillaValet.keychainQuery()
+        let valetKeychainQuery = vanillaValet.baseKeychainQuery
 
         // Our test Valet has not yet been written to, migration should fail:
         XCTAssertThrowsError(try anotherFlavor.migrateObjects(matching: valetKeychainQuery, removeOnCompletion: false)) { error in

--- a/Tests/ValetObjectiveCBridgeTests/VALSecureEnclaveValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALSecureEnclaveValetTests.m
@@ -26,6 +26,25 @@
     return @"identifier";
 }
 
+- (NSString *)appIDPrefix;
+{
+    return @"9XUJ7M53NG";
+}
+
+- (NSString *)sharedAccessGroupIdentifier;
+{
+#if TARGET_OS_IPHONE
+    return @"com.squareup.Valet-iOS-Test-Host-App";
+#elif TARGET_OS_WATCH
+    return @"com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension";
+#elif TARGET_OS_MAC
+    return @"com.squareup.Valet-macOS-Test-Host-App";
+#else
+    // This will fail
+    return @"";
+#endif
+}
+
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
     VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
@@ -62,35 +81,35 @@
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
-    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
+    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
     XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
     XCTAssertEqual([valet class], [VALSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlUserPresence;
 {
-    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlUserPresence];
+    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
     XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
     XCTAssertEqual([valet class], [VALSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricAny;
 {
-    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
+    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
     XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
     XCTAssertEqual([valet class], [VALSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricCurrentSet;
 {
-    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
     XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
     XCTAssertEqual([valet class], [VALSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    VALSecureEnclaveValet *const valet = [VALSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
     XCTAssertNil(valet);
 }
 

--- a/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
@@ -26,6 +26,25 @@
     return @"identifier";
 }
 
+- (NSString *)appIDPrefix;
+{
+    return @"9XUJ7M53NG";
+}
+
+- (NSString *)sharedAccessGroupIdentifier;
+{
+#if TARGET_OS_IPHONE
+    return @"com.squareup.Valet-iOS-Test-Host-App";
+#elif TARGET_OS_WATCH
+    return @"com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension";
+#elif TARGET_OS_MAC
+    return @"com.squareup.Valet-macOS-Test-Host-App";
+#else
+    // This will fail
+    return @"";
+#endif
+}
+
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
     if (@available(tvOS 11.0, *)) {
@@ -73,7 +92,7 @@
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
     if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
+        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
         XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
         XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
     }
@@ -82,7 +101,7 @@
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlUserPresence;
 {
     if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlUserPresence];
+        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
         XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
         XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
     }
@@ -91,7 +110,7 @@
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricAny;
 {
     if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
+        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
         XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
         XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
     }
@@ -100,7 +119,7 @@
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricCurrentSet;
 {
     if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
         XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
         XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
     }
@@ -109,7 +128,7 @@
 - (void)test_sharedAccessGroupValetWithIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
     if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
         XCTAssertNil(valet);
     }
 }

--- a/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
@@ -26,6 +26,25 @@
     return @"identifier";
 }
 
+- (NSString *)appIDPrefix;
+{
+    return @"9XUJ7M53NG";
+}
+
+- (NSString *)sharedAccessGroupIdentifier;
+{
+#if TARGET_OS_IPHONE
+    return @"com.squareup.Valet-iOS-Test-Host-App";
+#elif TARGET_OS_WATCH
+    return @"com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension";
+#elif TARGET_OS_MAC
+    return @"com.squareup.Valet-macOS-Test-Host-App";
+#else
+    // This will fail
+    return @"";
+#endif
+}
+
 - (void)test_valetWithIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenUnlocked;
 {
     VALValet *const valet = [VALValet valetWithIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlocked];
@@ -89,62 +108,62 @@
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenUnlocked;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlocked];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenUnlocked];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlocked);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityAfterFirstUnlock;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityAfterFirstUnlock];
     XCTAssertEqual(valet.accessibility, VALAccessibilityAfterFirstUnlock);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenPasscodeSetThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenPasscodeSetThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenUnlockedThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlockedThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityAfterFirstUnlockThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityAfterFirstUnlockThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithSharedAccessGroupIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    VALValet *const valet = [VALValet valetWithSharedAccessGroupIdentifier:@"" accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
+    VALValet *const valet = [VALValet sharedAccessGroupValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:@"" accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
     XCTAssertNil(valet);
 }
 
 - (void)test_iCloudValetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALCloudAccessibilityWhenUnlocked;
 {
-    VALValet *const valet = [VALValet iCloudValetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALCloudAccessibilityWhenUnlocked];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALCloudAccessibilityWhenUnlocked];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlocked);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_iCloudValetWithSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALCloudAccessibilityAfterFirstUnlock;
 {
-    VALValet *const valet = [VALValet iCloudValetWithSharedAccessGroupIdentifier:self.identifier accessibility:VALCloudAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALCloudAccessibilityAfterFirstUnlock];
     XCTAssertEqual(valet.accessibility, VALAccessibilityAfterFirstUnlock);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_iCloudValetWithSharedAccessGroupIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    VALValet *const valet = [VALValet iCloudValetWithSharedAccessGroupIdentifier:@"" accessibility:VALCloudAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix sharedAccessGroupIdentifier:@"" accessibility:VALCloudAccessibilityAfterFirstUnlock];
     XCTAssertNil(valet);
 }
 

--- a/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
@@ -234,62 +234,62 @@
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenUnlocked;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlocked];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenUnlocked];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlocked);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityAfterFirstUnlock;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityAfterFirstUnlock];
     XCTAssertEqual(valet.accessibility, VALAccessibilityAfterFirstUnlock);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenPasscodeSetThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenPasscodeSetThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenPasscodeSetThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityWhenUnlockedThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityWhenUnlockedThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlockedThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALAccessibilityAfterFirstUnlockThisDeviceOnly;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
     XCTAssertEqual(valet.accessibility, VALAccessibilityAfterFirstUnlockThisDeviceOnly);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_valetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    VALValet *const valet = [VALValet valetWithExplicitlySetSharedAccessGroupIdentifier:@"" accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
+    VALValet *const valet = [VALValet valetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:@"" accessibility:VALAccessibilityAfterFirstUnlockThisDeviceOnly];
     XCTAssertNil(valet);
 }
 
 - (void)test_iCloudValetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALCloudAccessibilityWhenUnlocked;
 {
-    VALValet *const valet = [VALValet iCloudValetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALCloudAccessibilityWhenUnlocked];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALCloudAccessibilityWhenUnlocked];
     XCTAssertEqual(valet.accessibility, VALAccessibilityWhenUnlocked);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_iCloudValetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsCorrectValet_VALCloudAccessibilityAfterFirstUnlock;
 {
-    VALValet *const valet = [VALValet iCloudValetWithExplicitlySetSharedAccessGroupIdentifier:self.identifier accessibility:VALCloudAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:self.sharedAccessGroupIdentifier accessibility:VALCloudAccessibilityAfterFirstUnlock];
     XCTAssertEqual(valet.accessibility, VALCloudAccessibilityAfterFirstUnlock);
     XCTAssertEqual([valet class], [VALValet class]);
 }
 
 - (void)test_iCloudValetWithExplicitlySetSharedAccessGroupIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    VALValet *const valet = [VALValet iCloudValetWithExplicitlySetSharedAccessGroupIdentifier:@"" accessibility:VALCloudAccessibilityAfterFirstUnlock];
+    VALValet *const valet = [VALValet iCloudValetWithAppIDPrefix:self.appIDPrefix explicitlySetSharedAccessGroupIdentifier:@"" accessibility:VALCloudAccessibilityAfterFirstUnlock];
     XCTAssertNil(valet);
 }
 

--- a/Tests/ValetTests/SecureEnclaveTests.swift
+++ b/Tests/ValetTests/SecureEnclaveTests.swift
@@ -41,7 +41,7 @@ class SecureEnclaveTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_sharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         SecureEnclaveAccessControl.allValues().forEach { accessControl in
             let backingService = SecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service

--- a/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
@@ -43,7 +43,7 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_sharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         SecureEnclaveAccessControl.allValues().forEach { accessControl in
             let backingService = SinglePromptSecureEnclaveValet.sharedAccessGroupValet(with: identifier, accessControl: accessControl).service

--- a/Tests/ValetTests/ValetTests.swift
+++ b/Tests/ValetTests/ValetTests.swift
@@ -41,7 +41,7 @@ class ValetTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_sharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.sharedAccessGroupValet(with: identifier, accessibility: accessibility).service
@@ -59,7 +59,7 @@ class ValetTests: XCTestCase
     }
 
     func test_init_createsCorrectBackingService_cloudSharedAccess() {
-        let identifier = ValetTests.identifier
+        let identifier = Valet.sharedAccessGroupIdentifier
 
         CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudSharedAccessGroupValet(with: identifier, accessibility: accessibility).service

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -128,25 +128,29 @@
 		165CDDCB204B26D400C96C2E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165CDDCA204B26D400C96C2E /* ViewController.swift */; };
 		165CDDCE204B26D400C96C2E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 165CDDCC204B26D400C96C2E /* Main.storyboard */; };
 		165CDDD0204B26D500C96C2E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 165CDDCF204B26D500C96C2E /* Assets.xcassets */; };
-		167E251023D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
-		167E251123D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
-		167E251223D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
 		167E24F123D4B89800889121 /* SinglePromptSecureEnclaveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0622A9C95400FC1142 /* SinglePromptSecureEnclaveIntegrationTests.swift */; };
-		167E250723D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
-		167E250823D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
-		167E250923D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
 		167E24FE23D6235000889121 /* KeychainErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E24FD23D6235000889121 /* KeychainErrorTests.swift */; };
 		167E24FF23D6235000889121 /* KeychainErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E24FD23D6235000889121 /* KeychainErrorTests.swift */; };
 		167E250023D6235000889121 /* KeychainErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E24FD23D6235000889121 /* KeychainErrorTests.swift */; };
 		167E250223D624EF00889121 /* MigrationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250123D624EF00889121 /* MigrationErrorTests.swift */; };
 		167E250323D624EF00889121 /* MigrationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250123D624EF00889121 /* MigrationErrorTests.swift */; };
 		167E250423D624EF00889121 /* MigrationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250123D624EF00889121 /* MigrationErrorTests.swift */; };
+		167E250723D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
+		167E250823D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
+		167E250923D62CAA00889121 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
+		167E251023D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
+		167E251123D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
+		167E251223D6328E00889121 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
 		168909381F7199D60057F636 /* Valet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26E6827C1BA8B3F900EFF4EA /* Valet.framework */; };
 		168909391F7199D60057F636 /* Valet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 26E6827C1BA8B3F900EFF4EA /* Valet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1693E29523B2D24600F8D97A /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693E29423B2D24600F8D97A /* KeychainError.swift */; };
 		1693E29623B2D24600F8D97A /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693E29423B2D24600F8D97A /* KeychainError.swift */; };
 		1693E29723B2D24600F8D97A /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693E29423B2D24600F8D97A /* KeychainError.swift */; };
 		1693E29823B2D24600F8D97A /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693E29423B2D24600F8D97A /* KeychainError.swift */; };
+		16967AE82405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */; };
+		16967AE92405CC7400DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */; };
+		16967AEA2405CC7500DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */; };
+		16967AEB2405CC7600DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */; };
 		169E9A6723D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 169E9A6423D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m */; };
 		169E9A6823D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 169E9A6423D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m */; };
 		169E9A6923D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 169E9A6423D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m */; };
@@ -417,11 +421,12 @@
 		165CDDCF204B26D500C96C2E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		165CDDD1204B26D500C96C2E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		165CDDD5204B26F700C96C2E /* Valet tvOS Test Host App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Valet tvOS Test Host App.entitlements"; sourceTree = "<group>"; };
-		167E250F23D6328E00889121 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
-		167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudAccessibilityTests.swift; sourceTree = "<group>"; };
 		167E24FD23D6235000889121 /* KeychainErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainErrorTests.swift; sourceTree = "<group>"; };
 		167E250123D624EF00889121 /* MigrationErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationErrorTests.swift; sourceTree = "<group>"; };
+		167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudAccessibilityTests.swift; sourceTree = "<group>"; };
+		167E250F23D6328E00889121 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		1693E29423B2D24600F8D97A /* KeychainError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
+		16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAccessGroupIdentifier.swift; sourceTree = "<group>"; };
 		169E9A6423D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VALSinglePromptSecureEnclaveValetTests.m; sourceTree = "<group>"; };
 		169E9A6523D181DC001B69F5 /* VALValetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VALValetTests.m; sourceTree = "<group>"; };
 		169E9A6623D181DC001B69F5 /* VALSecureEnclaveValetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VALSecureEnclaveValetTests.m; sourceTree = "<group>"; };
@@ -635,6 +640,7 @@
 				1612FD7822A9CAAB00FC1142 /* SecureEnclaveAccessControl.swift */,
 				1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */,
 				1612FD7B22A9CAAB00FC1142 /* SecureEnclaveValet.swift */,
+				16967AE72405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift */,
 				1612FD7C22A9CAAB00FC1142 /* Identifier.swift */,
 				1612FD7022A9CAAB00FC1142 /* Internal */,
 			);
@@ -1552,6 +1558,7 @@
 				1612FD9F22A9CAAB00FC1142 /* Configuration.swift in Sources */,
 				1612FDA322A9CAAB00FC1142 /* Accessibility.swift in Sources */,
 				1612FD7F22A9CAAB00FC1142 /* MigrationError.swift in Sources */,
+				16967AEA2405CC7500DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */,
 				1612FD9722A9CAAB00FC1142 /* Service.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1596,6 +1603,7 @@
 				1612FDA022A9CAAB00FC1142 /* Configuration.swift in Sources */,
 				1612FDA422A9CAAB00FC1142 /* Accessibility.swift in Sources */,
 				1612FD8022A9CAAB00FC1142 /* MigrationError.swift in Sources */,
+				16967AEB2405CC7600DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */,
 				1612FD9822A9CAAB00FC1142 /* Service.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1613,6 +1621,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16967AE82405CAF800DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */,
 				1693E29523B2D24600F8D97A /* KeychainError.swift in Sources */,
 				1612FDB922A9CAAB00FC1142 /* SecureEnclaveValet.swift in Sources */,
 				1612FD8D22A9CAAB00FC1142 /* Valet.swift in Sources */,
@@ -1647,6 +1656,7 @@
 				1612FD9E22A9CAAB00FC1142 /* Configuration.swift in Sources */,
 				1612FDA222A9CAAB00FC1142 /* Accessibility.swift in Sources */,
 				1612FD7E22A9CAAB00FC1142 /* MigrationError.swift in Sources */,
+				16967AE92405CC7400DC2B2D /* SharedAccessGroupIdentifier.swift in Sources */,
 				1612FD9622A9CAAB00FC1142 /* Service.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This PR removes the magic that automatically determined the shared access group.

There are two big drivers behind this PR:
1. #197 made this code significantly more complex, since the app ID prefix could no longer always be accessed. This is discussed some in https://github.com/square/Valet/issues/179#issuecomment-575440030.
1. The auto-magical determining of the App ID prefix is non-deterministic on particular iOS versions when an app has gone through the process of [changing its App ID prefix](https://developer.apple.com/library/archive/technotes/tn2311/_index.html). Airbnb found that on iOS 12, the `sharedAccessGroupPrefix` returned the old App ID, where on iOS 13 the `sharedAccessGroupPrefix` returned our new App ID. This non-determinism was only found on App Store signed builds – debug builds worked. Given the possibility of incorrect behavior by this code, we believe it is best to be explicit.

Note that I need to add this change to the Valet 4 migration guide prior to merging Valet 4 to `master`. I'm tracking that in https://github.com/square/Valet/issues/179#issuecomment-568956038