### PR TITLE
Remove version from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,4 +23,3 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v5]
 )
-let version = Version(4, 0, 0)


### PR DESCRIPTION
This line isn't needed. SPM works with the current tag (there is no mention of the `version` field in the current [Package documentation](https://developer.apple.com/documentation/swift_packages/package)).

Shout out to @GeorgeLyon for teaching me that this field was not necessary.