### PR TITLE
Rename MigrationError cases with `InQueryResult` to `ToMigrate`

### DIFF
--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -232,7 +232,7 @@ internal final class Keychain {
             retrievedItemsToMigrate = multipleMatches
 
         } else {
-            throw MigrationError.dataInQueryResultInvalid
+            throw MigrationError.dataToMigrateInvalid
         }
         
         // Now that we have the persistent refs with attributes, get the data associated with each keychain entry.
@@ -251,7 +251,7 @@ internal final class Keychain {
             do {
                 let data: Data = try SecItem.copy(matching: retrieveDataQuery)
                 guard !data.isEmpty else {
-                    throw MigrationError.dataInQueryResultInvalid
+                    throw MigrationError.dataToMigrateInvalid
                 }
                 
                 var retrievedItemToMigrateWithData = retrievedItem
@@ -275,21 +275,21 @@ internal final class Keychain {
             }
             
             guard !key.isEmpty else {
-                throw MigrationError.keyInQueryResultInvalid
+                throw MigrationError.keyToMigrateInvalid
             }
             
             guard !keysToMigrate.contains(key) else {
-                throw MigrationError.duplicateKeyInQueryResult
+                throw MigrationError.duplicateKeyToMigrate
             }
             
             guard let data = keychainEntry[kSecValueData as String] as? Data, !data.isEmpty else {
-                throw MigrationError.dataInQueryResultInvalid
+                throw MigrationError.dataToMigrateInvalid
             }
 
             if Keychain.performCopy(forKey: key, options: destinationAttributes) == errSecItemNotFound {
                 keysToMigrate.insert(key)
             } else {
-                throw MigrationError.keyInQueryResultAlreadyExistsInValet
+                throw MigrationError.keyToMigrateAlreadyExistsInValet
             }
         }
         
@@ -305,12 +305,12 @@ internal final class Keychain {
         for keychainEntry in retrievedItemsToMigrateWithData {
             guard let key = keychainEntry[kSecAttrAccount as String] as? String else {
                 revertMigration()
-                throw MigrationError.keyInQueryResultInvalid
+                throw MigrationError.keyToMigrateInvalid
             }
 
             guard let value = keychainEntry[kSecValueData as String] as? Data else {
                 revertMigration()
-                throw MigrationError.dataInQueryResultInvalid
+                throw MigrationError.dataToMigrateInvalid
             }
 
             do {

--- a/Sources/Valet/MigrationError.swift
+++ b/Sources/Valet/MigrationError.swift
@@ -25,13 +25,13 @@ import Foundation
 public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, Equatable {
     /// Migration failed because the keychain query was not valid.
     case invalidQuery
-    /// Migration failed because a key in the query result could not be read.
+    /// Migration failed because a key staged for migration was empty.
     case keyToMigrateInvalid
-    /// Migration failed because some data in the query result could not be read.
+    /// Migration failed because some data staged for migration was empty.
     case dataToMigrateInvalid
-    /// Migration failed because two keys with the same value were found in the keychain.
+    /// Migration failed because two equivalent keys were staged for migration.
     case duplicateKeyToMigrate
-    /// Migration failed because a key in the keychain duplicates a key already managed by Valet.
+    /// Migration failed because a key staged for migration duplicates a key already managed by Valet.
     case keyToMigrateAlreadyExistsInValet
     /// Migration failed because removing the migrated data from the keychain failed.
     case removalFailed

--- a/Sources/Valet/MigrationError.swift
+++ b/Sources/Valet/MigrationError.swift
@@ -25,9 +25,9 @@ import Foundation
 public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, Equatable {
     /// Migration failed because the keychain query was not valid.
     case invalidQuery
-    /// Migration failed because a key staged for migration was empty.
+    /// Migration failed because a key staged for migration was invalid.
     case keyToMigrateInvalid
-    /// Migration failed because some data staged for migration was empty.
+    /// Migration failed because some data staged for migration was invalid.
     case dataToMigrateInvalid
     /// Migration failed because two equivalent keys were staged for migration.
     case duplicateKeyToMigrate

--- a/Sources/Valet/MigrationError.swift
+++ b/Sources/Valet/MigrationError.swift
@@ -26,13 +26,13 @@ public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, E
     /// Migration failed because the keychain query was not valid.
     case invalidQuery
     /// Migration failed because a key in the query result could not be read.
-    case keyInQueryResultInvalid
+    case keyToMigrateInvalid
     /// Migration failed because some data in the query result could not be read.
-    case dataInQueryResultInvalid
+    case dataToMigrateInvalid
     /// Migration failed because two keys with the same value were found in the keychain.
-    case duplicateKeyInQueryResult
+    case duplicateKeyToMigrate
     /// Migration failed because a key in the keychain duplicates a key already managed by Valet.
-    case keyInQueryResultAlreadyExistsInValet
+    case keyToMigrateAlreadyExistsInValet
     /// Migration failed because removing the migrated data from the keychain failed.
     case removalFailed
 
@@ -41,10 +41,10 @@ public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, E
     public var description: String {
         switch self {
         case .invalidQuery: return "MigrationError.invalidQuery"
-        case .keyInQueryResultInvalid: return "MigrationError.keyInQueryResultInvalid"
-        case .dataInQueryResultInvalid: return "MigrationError.dataInQueryResultInvalid"
-        case .duplicateKeyInQueryResult: return "MigrationError.duplicateKeyInQueryResult"
-        case .keyInQueryResultAlreadyExistsInValet: return "MigrationError.keyInQueryResultAlreadyExistsInValet"
+        case .keyToMigrateInvalid: return "MigrationError.keyToMigrateInvalid"
+        case .dataToMigrateInvalid: return "MigrationError.dataToMigrateInvalid"
+        case .duplicateKeyToMigrate: return "MigrationError.duplicateKeyToMigrate"
+        case .keyToMigrateAlreadyExistsInValet: return "MigrationError.keyToMigrateAlreadyExistsInValet"
         case .removalFailed: return "MigrationError.removalFailed"
         }
     }

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -689,7 +689,7 @@ class ValetIntegrationTests: XCTestCase
         }
     }
 
-    func test_migrateObjectsMatching_bailsOutIfConflictExistsInQueryResult() throws
+    func test_migrateObjectsMatching_bailsOutIfConflictExistsToMigrate() throws
     {
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -704,7 +704,7 @@ class ValetIntegrationTests: XCTestCase
         ]
 
         XCTAssertThrowsError(try migrationValet.migrateObjects(matching: conflictingQuery, removeOnCompletion: false)) { error in
-            XCTAssertEqual(error as? MigrationError, .duplicateKeyInQueryResult)
+            XCTAssertEqual(error as? MigrationError, .duplicateKeyToMigrate)
         }
     }
 
@@ -729,7 +729,7 @@ class ValetIntegrationTests: XCTestCase
             kSecAttrService as String: identifier
         ]
         XCTAssertThrowsError(try vanillaValet.migrateObjects(matching: query, removeOnCompletion: false)) { error in
-            XCTAssertEqual(error as? MigrationError, .keyInQueryResultInvalid)
+            XCTAssertEqual(error as? MigrationError, .keyToMigrateInvalid)
         }
     }
     
@@ -829,7 +829,7 @@ class ValetIntegrationTests: XCTestCase
         XCTAssertEqual(keyValuePairs.count, try anotherFlavor.allKeys().count)
 
         XCTAssertThrowsError(try vanillaValet.migrateObjects(from: anotherFlavor, removeOnCompletion: true)) { error in
-            XCTAssertEqual(error as? MigrationError, .keyInQueryResultAlreadyExistsInValet)
+            XCTAssertEqual(error as? MigrationError, .keyToMigrateAlreadyExistsInValet)
         }
 
         // Neither Valet should have seen any changes.

--- a/Tests/ValetTests/MigrationErrorTests.swift
+++ b/Tests/ValetTests/MigrationErrorTests.swift
@@ -27,14 +27,14 @@ final class MigrationErrorTests: XCTestCase {
             switch $0 {
             case .invalidQuery:
                 XCTAssertEqual($0.description, "MigrationError.invalidQuery")
-            case .keyInQueryResultInvalid:
-                XCTAssertEqual($0.description, "MigrationError.keyInQueryResultInvalid")
-            case .dataInQueryResultInvalid:
-                XCTAssertEqual($0.description, "MigrationError.dataInQueryResultInvalid")
-            case .duplicateKeyInQueryResult:
-                XCTAssertEqual($0.description, "MigrationError.duplicateKeyInQueryResult")
-            case .keyInQueryResultAlreadyExistsInValet:
-                XCTAssertEqual($0.description, "MigrationError.keyInQueryResultAlreadyExistsInValet")
+            case .keyToMigrateInvalid:
+                XCTAssertEqual($0.description, "MigrationError.keyToMigrateInvalid")
+            case .dataToMigrateInvalid:
+                XCTAssertEqual($0.description, "MigrationError.dataToMigrateInvalid")
+            case .duplicateKeyToMigrate:
+                XCTAssertEqual($0.description, "MigrationError.duplicateKeyToMigrate")
+            case .keyToMigrateAlreadyExistsInValet:
+                XCTAssertEqual($0.description, "MigrationError.keyToMigrateAlreadyExistsInValet")
             case .removalFailed:
                 XCTAssertEqual($0.description, "MigrationError.removalFailed")
             }


### PR DESCRIPTION
This PR updates the case names in `MigrationError` to be more future-proofed. Previously, we explicitly specified that something was wrong with the query result to be migrated. Now we're committing to something begin wrong in the key/value pairs staged to be migrated.

This PR helps us achieve #226 by making the names of these cases less specific to the current migration API. Since this PR represents a breaking API change, it'd be best to get it in before we release Valet 4.