### PR TITLE
Add ability to transform values on migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ However, because the Keychain is effectively disk storage, there is no guarantee
 
 ### Migrating Existing Keychain Values into Valet
 
-Already using the Keychain and no longer want to maintain your own Keychain code? We feel you. That’s why we wrote `migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool)`. This method allows you to migrate all your existing Keychain entries to a Valet instance in one line. Just pass in a Dictionary with the `kSecClass`, `kSecAttrService`, and any other `kSecAttr*` attributes you use – we’ll migrate the data for you.
+Already using the Keychain and no longer want to maintain your own Keychain code? We feel you. That’s why we wrote `migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool)`. This method allows you to migrate all your existing Keychain entries to a Valet instance in one line. Just pass in a Dictionary with the `kSecClass`, `kSecAttrService`, and any other `kSecAttr*` attributes you use – we’ll migrate the data for you. If you need more control over how your data is migrated, use `migrateObjects(matching query: [String : AnyHashable], compactMap: (MigratableKeyValuePair<AnyHashable>) throws -> MigratableKeyValuePair<String>?)` to filter or remap keys:value pairs as part of your migration.
 
 ### Integrating Valet into a macOS application
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ However, because the Keychain is effectively disk storage, there is no guarantee
 
 ### Migrating Existing Keychain Values into Valet
 
-Already using the Keychain and no longer want to maintain your own Keychain code? We feel you. That’s why we wrote `migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool)`. This method allows you to migrate all your existing Keychain entries to a Valet instance in one line. Just pass in a Dictionary with the `kSecClass`, `kSecAttrService`, and any other `kSecAttr*` attributes you use – we’ll migrate the data for you. If you need more control over how your data is migrated, use `migrateObjects(matching query: [String : AnyHashable], compactMap: (MigratableKeyValuePair<AnyHashable>) throws -> MigratableKeyValuePair<String>?)` to filter or remap keys:value pairs as part of your migration.
+Already using the Keychain and no longer want to maintain your own Keychain code? We feel you. That’s why we wrote `migrateObjects(matching query: [String : AnyHashable], removeOnCompletion: Bool)`. This method allows you to migrate all your existing Keychain entries to a Valet instance in one line. Just pass in a Dictionary with the `kSecClass`, `kSecAttrService`, and any other `kSecAttr*` attributes you use – we’ll migrate the data for you. If you need more control over how your data is migrated, use `migrateObjects(matching query: [String : AnyHashable], compactMap: (MigratableKeyValuePair<AnyHashable>) throws -> MigratableKeyValuePair<String>?)` to filter or remap key:value pairs as part of your migration.
 
 ### Integrating Valet into a macOS application
 

--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -269,7 +269,11 @@ internal final class Keychain {
         // Sanity check that we are capable of migrating the data.
         var keyValuePairsToMigrate = [String: Data]()
         for keychainEntry in retrievedItemsToMigrateWithData {
-            guard let key = keychainEntry[kSecAttrAccount as String], key as? String != Keychain.canaryKey else {
+            guard let key = keychainEntry[kSecAttrAccount as String] else {
+                throw MigrationError.keyToMigrateInvalid
+            }
+
+            guard key as? String != Keychain.canaryKey else {
                 // We don't care about this key. Move along.
                 continue
             }

--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -174,55 +174,55 @@ internal final class Keychain {
     }
     
     // MARK: Migration
-    
-    internal static func migrateObjects(matching query: [String : AnyHashable], into destinationAttributes: [String : AnyHashable], removeOnCompletion: Bool) throws {
+
+    internal static func migrateObjects(matching query: [String : AnyHashable], into destinationAttributes: [String : AnyHashable], compactMap: (MigratableKeyValuePair<AnyHashable>) throws -> MigratableKeyValuePair<String>?) throws {
         guard !query.isEmpty else {
             // Migration requires secItemQuery to contain values.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecMatchLimit as String] as? String as CFString? != kSecMatchLimitOne else {
             // Migration requires kSecMatchLimit to be set to kSecMatchLimitAll.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecReturnData as String] as? Bool != true else {
             // kSecReturnData is not supported in a migration query.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecReturnAttributes as String] as? Bool != false else {
             // Migration requires kSecReturnAttributes to be set to kCFBooleanTrue.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecReturnRef as String] as? Bool != true else {
             // kSecReturnRef is not supported in a migration query.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecReturnPersistentRef as String] as? Bool != false else {
             // Migration requires kSecReturnPersistentRef to be set to kCFBooleanTrue.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecClass as String] as? String as CFString? == kSecClassGenericPassword else {
             // Migration requires kSecClass to be set to kSecClassGenericPassword to avoid data loss.
             throw MigrationError.invalidQuery
         }
-        
+
         guard query[kSecAttrAccessControl as String] == nil else {
             // kSecAttrAccessControl is not supported in a migration query. Keychain items can not be migrated en masse from the Secure Enclave.
             throw MigrationError.invalidQuery
         }
-        
+
         var secItemQuery = query
         secItemQuery[kSecMatchLimit as String] = kSecMatchLimitAll
         secItemQuery[kSecReturnAttributes as String] = true
         secItemQuery[kSecReturnData as String] = false
         secItemQuery[kSecReturnRef as String] = false
         secItemQuery[kSecReturnPersistentRef as String] = true
-        
+
         let collection: Any = try SecItem.copy(matching: secItemQuery)
         let retrievedItemsToMigrate: [[String: AnyHashable]]
         if let singleMatch = collection as? [String : AnyHashable] {
@@ -234,7 +234,7 @@ internal final class Keychain {
         } else {
             throw MigrationError.dataToMigrateInvalid
         }
-        
+
         // Now that we have the persistent refs with attributes, get the data associated with each keychain entry.
         var retrievedItemsToMigrateWithData = [[String : AnyHashable]]()
         for retrievedItem in retrievedItemsToMigrate {
@@ -242,7 +242,7 @@ internal final class Keychain {
                 throw KeychainError.couldNotAccessKeychain
 
             }
-            
+
             let retrieveDataQuery: [String : AnyHashable] = [
                 kSecValuePersistentRef as String : retrievedPersistentRef,
                 kSecReturnData as String : true
@@ -253,7 +253,7 @@ internal final class Keychain {
                 guard !data.isEmpty else {
                     throw MigrationError.dataToMigrateInvalid
                 }
-                
+
                 var retrievedItemToMigrateWithData = retrievedItem
                 retrievedItemToMigrateWithData[kSecValueData as String] = data
                 retrievedItemsToMigrateWithData.append(retrievedItemToMigrateWithData)
@@ -265,34 +265,44 @@ internal final class Keychain {
                 throw error
             }
         }
-        
+
         // Sanity check that we are capable of migrating the data.
-        var keysToMigrate = Set<String>()
+        var keyValuePairsToMigrate = [String: Data]()
         for keychainEntry in retrievedItemsToMigrateWithData {
-            guard let key = keychainEntry[kSecAttrAccount as String] as? String, key != Keychain.canaryKey else {
+            guard let key = keychainEntry[kSecAttrAccount as String], key as? String != Keychain.canaryKey else {
                 // We don't care about this key. Move along.
                 continue
             }
-            
-            guard !key.isEmpty else {
-                throw MigrationError.keyToMigrateInvalid
-            }
-            
-            guard !keysToMigrate.contains(key) else {
-                throw MigrationError.duplicateKeyToMigrate
-            }
-            
-            guard let data = keychainEntry[kSecValueData as String] as? Data, !data.isEmpty else {
+
+            guard let data = keychainEntry[kSecValueData as String] as? Data else {
+                // This state should be impossible, per Apple's documentation for `kSecValueData`.
                 throw MigrationError.dataToMigrateInvalid
             }
 
-            if Keychain.performCopy(forKey: key, options: destinationAttributes) == errSecItemNotFound {
-                keysToMigrate.insert(key)
+            guard let migratablePair = try compactMap(MigratableKeyValuePair<AnyHashable>(key: key, value: data)) else {
+                // We don't care about this key. Move along.
+                continue
+            }
+
+            guard !migratablePair.key.isEmpty else {
+                throw MigrationError.keyToMigrateInvalid
+            }
+
+            guard keyValuePairsToMigrate[migratablePair.key] == nil else {
+                throw MigrationError.duplicateKeyToMigrate
+            }
+
+            guard !migratablePair.value.isEmpty else {
+                throw MigrationError.dataToMigrateInvalid
+            }
+
+            if Keychain.performCopy(forKey: migratablePair.key, options: destinationAttributes) == errSecItemNotFound {
+                keyValuePairsToMigrate[migratablePair.key] = migratablePair.value
             } else {
                 throw MigrationError.keyToMigrateAlreadyExistsInValet
             }
         }
-        
+
         // All looks good. Time to actually migrate.
         var alreadyMigratedKeys = [String]()
         func revertMigration() {
@@ -301,33 +311,40 @@ internal final class Keychain {
                 try? Keychain.removeObject(forKey: alreadyMigratedKey, options: destinationAttributes)
             }
         }
-        
-        for keychainEntry in retrievedItemsToMigrateWithData {
-            guard let key = keychainEntry[kSecAttrAccount as String] as? String else {
-                revertMigration()
-                throw MigrationError.keyToMigrateInvalid
-            }
 
-            guard let value = keychainEntry[kSecValueData as String] as? Data else {
-                revertMigration()
-                throw MigrationError.dataToMigrateInvalid
-            }
-
+        for keyValuePair in keyValuePairsToMigrate {
             do {
-                try Keychain.setObject(value, forKey: key, options: destinationAttributes)
-                alreadyMigratedKeys.append(key)
+                try Keychain.setObject(keyValuePair.value, forKey: keyValuePair.key, options: destinationAttributes)
+                alreadyMigratedKeys.append(keyValuePair.key)
             } catch {
                 revertMigration()
                 throw error
             }
         }
-        
+    }
+
+    internal static func migrateObjects(matching query: [String : AnyHashable], into destinationAttributes: [String : AnyHashable], removeOnCompletion: Bool) throws {
+        let keysInKeychainPreMigration = Set(try Keychain.allKeys(options: destinationAttributes))
+
+        try migrateObjects(matching: query, into: destinationAttributes) { keychainKeyValuePair in
+            guard let key = keychainKeyValuePair.key as? String else {
+                throw MigrationError.keyToMigrateInvalid
+            }
+            return MigratableKeyValuePair(key: key, value: keychainKeyValuePair.value)
+        }
+
         // Remove data if requested.
         if removeOnCompletion {
             do {
                 try Keychain.removeAllObjects(matching: query)
             } catch {
-                revertMigration()
+                if let allKeysPostPotentiallyPartialMigration = try? Keychain.allKeys(options: destinationAttributes) {
+                    let migratedKeys = allKeysPostPotentiallyPartialMigration.filter { !keysInKeychainPreMigration.contains($0) }
+                    migratedKeys.forEach { migratedKey in
+                        try? Keychain.removeObject(forKey: migratedKey, options: destinationAttributes)
+                    }
+                }
+
                 throw MigrationError.removalFailed
             }
 

--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -349,7 +349,7 @@ internal final class Keychain {
 
     internal static func revertMigration(into destinationAttributes: [String : AnyHashable], keysInKeychainPreMigration: Set<String>) {
         if let allKeysPostPotentiallyPartialMigration = try? Keychain.allKeys(options: destinationAttributes) {
-            let migratedKeys = allKeysPostPotentiallyPartialMigration.filter { !keysInKeychainPreMigration.contains($0) }
+            let migratedKeys = allKeysPostPotentiallyPartialMigration.subtracting(keysInKeychainPreMigration)
             migratedKeys.forEach { migratedKey in
                 try? Keychain.removeObject(forKey: migratedKey, options: destinationAttributes)
             }

--- a/Sources/Valet/MigratableKeyValuePair.swift
+++ b/Sources/Valet/MigratableKeyValuePair.swift
@@ -21,7 +21,7 @@
 import Foundation
 
 /// A struct that represented a key:value pair that can be migrated.
-public struct MigratableKeyValuePair<KeyType: Hashable>: Hashable {
+public struct MigratableKeyValuePair<Key: Hashable>: Hashable {
 
     // MARK: Initialization
 
@@ -29,7 +29,7 @@ public struct MigratableKeyValuePair<KeyType: Hashable>: Hashable {
     /// - Parameters:
     ///   - key: The key in the key:value pair.
     ///   - value: The value in the key:value pair.
-    public init(key: KeyType, value: Data) {
+    public init(key: Key, value: Data) {
         self.key = key
         self.value = value
     }
@@ -38,7 +38,7 @@ public struct MigratableKeyValuePair<KeyType: Hashable>: Hashable {
     /// - Parameters:
     ///   - key: The key in the key:value pair.
     ///   - value: The desired value in the key:value pair, represented as a String.
-    public init(key: KeyType, value: String) {
+    public init(key: Key, value: String) {
         self.key = key
         self.value = Data(value.utf8)
     }
@@ -46,7 +46,7 @@ public struct MigratableKeyValuePair<KeyType: Hashable>: Hashable {
     // MARK: Public
 
     /// The key in the key:value pair.
-    public let key: KeyType
+    public let key: Key
     /// The value in the key:value pair.
     public let value: Data
 }
@@ -103,6 +103,7 @@ public class ObjectiveCCompatibilityMigratableKeyValuePairOutput: NSObject {
     // MARK: Public Static Methods
 
     /// A sentinal `ObjectiveCCompatibilityMigratableKeyValuePairOutput` that conveys that the migration should be prevented.
+    @available(swift, obsoleted: 1.0)
     @objc
     public static func preventMigration() -> ObjectiveCCompatibilityMigratableKeyValuePairOutput {
         ObjectiveCCompatibilityPreventMigrationOutput()

--- a/Sources/Valet/MigratableKeyValuePair.swift
+++ b/Sources/Valet/MigratableKeyValuePair.swift
@@ -1,0 +1,133 @@
+//
+//  MigratableKeyValuePair.swift
+//  Valet
+//
+//  Created by Dan Federman on 5/20/20.
+//  Copyright © 2020 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A struct that represented a key:value pair that can be migrated.
+public struct MigratableKeyValuePair<KeyType: Hashable>: Hashable {
+
+    // MARK: Initialization
+
+    /// Creates a migratable key:value pair with the provided inputs.
+    /// - Parameters:
+    ///   - key: The key in the key:value pair.
+    ///   - value: The value in the key:value pair.
+    public init(key: KeyType, value: Data) {
+        self.key = key
+        self.value = value
+    }
+
+    /// Creates a migratable key:value pair with the provided inputs.
+    /// - Parameters:
+    ///   - key: The key in the key:value pair.
+    ///   - value: The desired value in the key:value pair, represented as a String.
+    public init(key: KeyType, value: String) {
+        self.key = key
+        self.value = Data(value.utf8)
+    }
+
+    // MARK: Public
+
+    /// The key in the key:value pair.
+    public let key: KeyType
+    /// The value in the key:value pair.
+    public let value: Data
+}
+
+// MARK: - Objective-C Compatibility
+
+@objc(VALMigratableKeyValuePairInput)
+public final class ObjectiveCCompatibilityMigratableKeyValuePairInput: NSObject {
+
+    // MARK: Initialization
+
+    internal init(key: Any, value: Data) {
+        self.key = key
+        self.value = value
+    }
+
+    // MARK: Public
+
+    /// The key in the key:value pair.
+    @objc
+    public let key: Any
+    /// The value in the key:value pair.
+    @objc
+    public let value: Data
+}
+
+@objc(VALMigratableKeyValuePairOutput)
+public class ObjectiveCCompatibilityMigratableKeyValuePairOutput: NSObject {
+
+    // MARK: Initialization
+
+    /// Creates a migratable key:value pair with the provided inputs.
+    /// - Parameters:
+    ///   - key: The key in the key:value pair.
+    ///   - value: The value in the key:value pair.
+    @objc
+    public init(key: String, value: Data) {
+        self.key = key
+        self.value = value
+        preventMigration = false
+    }
+
+    /// Creates a migratable key:value pair with the provided inputs.
+    /// - Parameters:
+    ///   - key: The key in the key:value pair.
+    ///   - stringValue: The desired value in the key:value pair, represented as a String.
+    @objc
+    public init(key: String, stringValue: String) {
+        self.key = key
+        self.value = Data(stringValue.utf8)
+        preventMigration = false
+    }
+
+    // MARK: Public Static Methods
+
+    /// A sentinal `ObjectiveCCompatibilityMigratableKeyValuePairOutput` that conveys that the migration should be prevented.
+    @objc
+    public static func preventMigration() -> ObjectiveCCompatibilityMigratableKeyValuePairOutput {
+        ObjectiveCCompatibilityPreventMigrationOutput()
+    }
+
+    // MARK: Public
+
+    /// The key in the key:value pair.
+    @objc
+    public let key: String
+    /// The value in the key:value pair.
+    @objc
+    public let value: Data
+
+    // MARK: Internal
+
+    internal fileprivate(set) var preventMigration: Bool
+
+}
+
+private final class ObjectiveCCompatibilityPreventMigrationOutput: ObjectiveCCompatibilityMigratableKeyValuePairOutput {
+
+    init() {
+        super.init(key: "", stringValue: "")
+        preventMigration = true
+    }
+
+}

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -705,7 +705,6 @@ extension Valet {
         }
     }
 
-
 }
 
 // MARK: - Testing

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -663,7 +663,6 @@ extension Valet {
     ///   - query: The query with which to retrieve existing keychain data via a call to SecItemCopyMatching.
     ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated. Returning `VALMigratableKeyValuePairOutput.preventMigration` will prevent migrating any key:value pairs.
     ///   - error: An error of type `KeychainError` or `MigrationError`.
-    /// - Note: The keychain is not modified if an error is thrown.
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsMatching:compactMap:error:)
     public func 🚫swift_migrateObjects(matching query: [String : AnyHashable], compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {
@@ -673,9 +672,8 @@ extension Valet {
     /// Migrates objects matching the input query into the receiving Valet instance.
     /// - Parameters:
     ///   - valet: The Valet used to retrieve the existing keychain data that should be migrated.
-    ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated.
+    ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated. Returning `VALMigratableKeyValuePairOutput.preventMigration` will prevent migrating any key:value pairs.
     ///   - error: An error of type `KeychainError` or `MigrationError`.
-    /// - Note: The keychain is not modified if an error is thrown.
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsFrom:compactMap:error:)
     public func 🚫swift_migrateObjects(from valet: Valet, compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -662,7 +662,7 @@ extension Valet {
     /// - Parameters:
     ///   - query: The query with which to retrieve existing keychain data via a call to SecItemCopyMatching.
     ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated.
-    /// - Throws: An error of type `KeychainError` or `MigrationError`.
+    ///   - error: An error of type `KeychainError` or `MigrationError`.
     /// - Note: The keychain is not modified if an error is thrown.
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsMatching:compactMap:error:)
@@ -674,7 +674,7 @@ extension Valet {
     /// - Parameters:
     ///   - valet: The Valet used to retrieve the existing keychain data that should be migrated.
     ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated.
-    /// - Throws: An error of type `KeychainError` or `MigrationError`. Will rethrow any error thrown by `compactMap`.
+    ///   - error: An error of type `KeychainError` or `MigrationError`.
     /// - Note: The keychain is not modified if an error is thrown.
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsFrom:compactMap:error:)

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -661,7 +661,7 @@ extension Valet {
     /// Migrates objects matching the input query into the receiving Valet instance.
     /// - Parameters:
     ///   - query: The query with which to retrieve existing keychain data via a call to SecItemCopyMatching.
-    ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated.
+    ///   - compactMap: A closure that transforms a key:value pair from the raw pair currently in the keychain into a key:value pair we'll insert into the destination Valet. Returning `nil` from this closure will cause that key:value pair not to be migrated. Returning `VALMigratableKeyValuePairOutput.preventMigration` will prevent migrating any key:value pairs.
     ///   - error: An error of type `KeychainError` or `MigrationError`.
     /// - Note: The keychain is not modified if an error is thrown.
     @available(swift, obsoleted: 1.0)

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -667,7 +667,7 @@ extension Valet {
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsMatching:compactMap:error:)
     public func 🚫swift_migrateObjects(matching query: [String : AnyHashable], compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {
-        try 🚫！swift_migrateObjects(matching: query, compactMap: compactMap)
+        try objc_compatibility_migrateObjects(matching: query, compactMap: compactMap)
     }
 
     /// Migrates objects matching the input query into the receiving Valet instance.
@@ -679,12 +679,12 @@ extension Valet {
     @available(swift, obsoleted: 1.0)
     @objc(migrateObjectsFrom:compactMap:error:)
     public func 🚫swift_migrateObjects(from valet: Valet, compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {
-        try 🚫！swift_migrateObjects(matching: valet.baseKeychainQuery, compactMap: compactMap)
+        try objc_compatibility_migrateObjects(matching: valet.baseKeychainQuery, compactMap: compactMap)
     }
 
     // MARK: Private Methods
 
-    private func 🚫！swift_migrateObjects(matching query: [String : AnyHashable], compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {
+    private func objc_compatibility_migrateObjects(matching query: [String : AnyHashable], compactMap: (ObjectiveCCompatibilityMigratableKeyValuePairInput) -> ObjectiveCCompatibilityMigratableKeyValuePairOutput?) throws {
         try execute(in: lock) {
             struct PreventedMigrationSentinel: Error {}
             do {

--- a/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
@@ -3,7 +3,7 @@
 //  Valet iOS
 //
 //  Created by Dan Federman on 5/20/20.
-//  Copyright © 2010 Square, Inc.
+//  Copyright © 2020 Square, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import XCTest
 @testable import Valet
 
 
-class KeychainIntegrationTests: XCTestCase {
+final class KeychainIntegrationTests: XCTestCase {
 
     func test_revertMigration_removesAllMigratedKeys() throws {
         guard testEnvironmentIsSigned() else {

--- a/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
@@ -1,0 +1,60 @@
+//
+//  KeychainIntegrationTests.swift
+//  Valet iOS
+//
+//  Created by Dan Federman on 5/20/20.
+//  Copyright © 2010 Square, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+@testable import Valet
+
+
+class KeychainIntegrationTests: XCTestCase {
+
+    func test_revertMigration_removesAllMigratedKeys() throws {
+        guard testEnvironmentIsSigned() else {
+            return
+        }
+
+        let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
+        try migrationValet.removeAllObjects()
+
+        let anotherValet = Valet.valet(with: Identifier(nonEmpty: #function)!, accessibility: .whenUnlocked)
+        try anotherValet.removeAllObjects()
+
+        let keyValuePairsToMigrate = [
+            "yo": "dawg",
+            "we": "heard",
+            "you": "like",
+            "migrating": "to",
+            "other": "valets"
+        ]
+
+        for (key, value) in keyValuePairsToMigrate {
+            try migrationValet.setString(value, forKey: key)
+        }
+
+        try anotherValet.setString("password", forKey: "accountName")
+        try anotherValet.migrateObjects(from: migrationValet, removeOnCompletion: false)
+        Keychain.revertMigration(into: anotherValet.baseKeychainQuery, keysInKeychainPreMigration: Set(["accountName"]))
+
+        XCTAssertEqual(try anotherValet.allKeys().count, 1)
+        XCTAssertEqual(try anotherValet.string(forKey: "accountName"), "password")
+    }
+
+}

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -824,7 +824,7 @@ class ValetIntegrationTests: XCTestCase
             }
         }
 
-        XCTAssertNil(try? anotherValet.string(forKey: key1))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key1))
         XCTAssertEqual(try? anotherValet.string(forKey: key2), "password2")
     }
 
@@ -859,8 +859,8 @@ class ValetIntegrationTests: XCTestCase
             }
         }
 
-        XCTAssertNil(try? anotherValet.string(forKey: key1))
-        XCTAssertNil(try? anotherValet.string(forKey: key2))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key1))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key2))
     }
 
     func test_migrateObjectsMatchingCompactMap_thrownErrorFromCompactMapIsRethrown() throws {
@@ -1071,7 +1071,7 @@ class ValetIntegrationTests: XCTestCase
             }
         }
 
-        XCTAssertNil(try? anotherValet.string(forKey: key1))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key1))
         XCTAssertEqual(try? anotherValet.string(forKey: key2), "password2")
     }
 
@@ -1103,8 +1103,8 @@ class ValetIntegrationTests: XCTestCase
             }
         }
 
-        XCTAssertNil(try? anotherValet.string(forKey: key1))
-        XCTAssertNil(try? anotherValet.string(forKey: key2))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key1))
+        XCTAssertFalse(try anotherValet.containsObject(forKey: key2))
     }
 
     func test_migrateObjectsFromValetCompactMap_thrownErrorFromCompactMapIsRethrown() throws {

--- a/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
@@ -63,7 +63,7 @@
 {
     return @"valet.test";
 }
-  
+
 - (BOOL)testEnvironmentIsSigned;
 {
     return NSBundle.mainBundle.bundleIdentifier != nil && ![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"com.apple.dt.xctest.tool"];

--- a/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALValetTests.m
@@ -314,6 +314,29 @@
     [otherValet removeAllObjectsAndReturnError:nil];
 }
 
+- (void)test_migrateObjectsMatching_compactMap_error_successfullyMigratesTransformedKey;
+{
+    if (![self testEnvironmentIsSigned]) {
+        return;
+    }
+    VALValet *const valet = [VALValet valetWithIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlocked];
+
+    [valet setString:@"password" forKey:NSStringFromSelector(_cmd) error:nil];
+
+    VALValet *const otherValet = [VALValet valetWithIdentifier:NSStringFromSelector(_cmd) accessibility:VALAccessibilityWhenUnlocked];
+    [otherValet migrateObjectsMatching:@{
+        (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService : @"VAL_VALValet_initWithIdentifier:accessibility:_identifier_AccessibleWhenUnlocked",
+    } compactMap:^VALMigratableKeyValuePairOutput * _Nullable(VALMigratableKeyValuePairInput * _Nonnull input) {
+        return [[VALMigratableKeyValuePairOutput alloc] initWithKey:@"transformed_key" value:input.value];
+    } error:nil];
+    XCTAssertEqualObjects([otherValet stringForKey:@"transformed_key" error:nil], @"password");
+
+    // Clean up.
+    [valet removeAllObjectsAndReturnError:nil];
+    [otherValet removeAllObjectsAndReturnError:nil];
+}
+
 - (void)test_migrateObjectsMatching_compactMap_error_successfullyMigratesTransformedValue;
 {
     if (![self testEnvironmentIsSigned]) {
@@ -331,6 +354,26 @@
         return [[VALMigratableKeyValuePairOutput alloc] initWithKey:input.key value:[@"12345" dataUsingEncoding:NSUTF8StringEncoding]];
     } error:nil];
     XCTAssertEqualObjects([otherValet stringForKey:NSStringFromSelector(_cmd) error:nil], @"12345");
+
+    // Clean up.
+    [valet removeAllObjectsAndReturnError:nil];
+    [otherValet removeAllObjectsAndReturnError:nil];
+}
+
+- (void)test_migrateObjectsFrom_compactMap_error_successfullyMigratesTransformedKey;
+{
+    if (![self testEnvironmentIsSigned]) {
+        return;
+    }
+    VALValet *const valet = [VALValet valetWithIdentifier:self.identifier accessibility:VALAccessibilityWhenUnlocked];
+
+    [valet setString:@"password" forKey:NSStringFromSelector(_cmd) error:nil];
+
+    VALValet *const otherValet = [VALValet valetWithIdentifier:NSStringFromSelector(_cmd) accessibility:VALAccessibilityWhenUnlocked];
+    [otherValet migrateObjectsFrom:valet compactMap:^VALMigratableKeyValuePairOutput * _Nullable(VALMigratableKeyValuePairInput * _Nonnull input) {
+        return [[VALMigratableKeyValuePairOutput alloc] initWithKey:@"transformed_key" value:input.value];
+    } error:nil];
+    XCTAssertEqualObjects([otherValet stringForKey:@"transformed_key" error:nil], @"password");
 
     // Clean up.
     [valet removeAllObjectsAndReturnError:nil];

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -190,6 +190,10 @@
 		32644C32248313210037F517 /* ValetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0D22A9C95500FC1142 /* ValetTests.swift */; };
 		32644C33248313210037F517 /* MigrationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250123D624EF00889121 /* MigrationErrorTests.swift */; };
 		32644C34248313210037F517 /* KeychainErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E24FD23D6235000889121 /* KeychainErrorTests.swift */; };
+		32DC88852475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
+		32DC88862475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
+		32DC88872475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
+		32DC88882475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
 		32E7115B2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115C2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115E2336B90800018E15 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0A22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift */; };
@@ -473,6 +477,7 @@
 		32C1ED1B224C85660063E91D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/Main.storyboard; sourceTree = "<group>"; };
 		32C1ED1C224C85820063E91D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/Main.storyboard; sourceTree = "<group>"; };
 		32C1ED1D224C85890063E91D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/ValetSecureElementTestMain.storyboard; sourceTree = "<group>"; };
+		32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratableKeyValuePair.swift; sourceTree = "<group>"; };
 		371150A51E2962D8004A45D4 /* Valet iOS Test Host App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Valet iOS Test Host App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		371150A71E2962D8004A45D4 /* ValetIOSTestHostAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValetIOSTestHostAppDelegate.swift; sourceTree = "<group>"; };
 		371150A91E2962D8004A45D4 /* ValetIOSTestHostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValetIOSTestHostViewController.swift; sourceTree = "<group>"; };
@@ -644,6 +649,7 @@
 		1612FD6A22A9CAAB00FC1142 /* Valet */ = {
 			isa = PBXGroup;
 			children = (
+				32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */,
 				1612FD6B22A9CAAB00FC1142 /* MigrationError.swift */,
 				1612FD6D22A9CAAB00FC1142 /* SecureEnclave.swift */,
 				1612FD6E22A9CAAB00FC1142 /* CloudAccessibility.swift */,
@@ -1565,6 +1571,7 @@
 				1612FD8F22A9CAAB00FC1142 /* Valet.swift in Sources */,
 				1612FD9322A9CAAB00FC1142 /* SecItem.swift in Sources */,
 				32E7115B2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */,
+				32DC88872475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */,
 				1612FDBF22A9CAAB00FC1142 /* Identifier.swift in Sources */,
 				1612FD8B22A9CAAB00FC1142 /* CloudAccessibility.swift in Sources */,
 				1612FD9B22A9CAAB00FC1142 /* Keychain.swift in Sources */,
@@ -1610,6 +1617,7 @@
 				1612FD9022A9CAAB00FC1142 /* Valet.swift in Sources */,
 				1612FD9422A9CAAB00FC1142 /* SecItem.swift in Sources */,
 				32E7115C2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */,
+				32DC88882475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */,
 				1612FDC022A9CAAB00FC1142 /* Identifier.swift in Sources */,
 				1612FD8C22A9CAAB00FC1142 /* CloudAccessibility.swift in Sources */,
 				1612FD9C22A9CAAB00FC1142 /* Keychain.swift in Sources */,
@@ -1654,6 +1662,7 @@
 				1612FDB922A9CAAB00FC1142 /* SecureEnclaveValet.swift in Sources */,
 				1612FD8D22A9CAAB00FC1142 /* Valet.swift in Sources */,
 				1612FD9122A9CAAB00FC1142 /* SecItem.swift in Sources */,
+				32DC88852475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */,
 				1612FDBD22A9CAAB00FC1142 /* Identifier.swift in Sources */,
 				1612FDB122A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift in Sources */,
 				1612FD8922A9CAAB00FC1142 /* CloudAccessibility.swift in Sources */,
@@ -1676,6 +1685,7 @@
 				1612FD8E22A9CAAB00FC1142 /* Valet.swift in Sources */,
 				1612FD9222A9CAAB00FC1142 /* SecItem.swift in Sources */,
 				1612FDBE22A9CAAB00FC1142 /* Identifier.swift in Sources */,
+				32DC88862475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */,
 				1612FDB222A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift in Sources */,
 				1612FD8A22A9CAAB00FC1142 /* CloudAccessibility.swift in Sources */,
 				1612FD9A22A9CAAB00FC1142 /* Keychain.swift in Sources */,

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -194,6 +194,9 @@
 		32DC88862475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
 		32DC88872475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
 		32DC88882475111D005A9BFA /* MigratableKeyValuePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */; };
+		32DC88932475BB9F005A9BFA /* KeychainIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88912475BA5F005A9BFA /* KeychainIntegrationTests.swift */; };
+		32DC88942475BBA1005A9BFA /* KeychainIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88912475BA5F005A9BFA /* KeychainIntegrationTests.swift */; };
+		32DC88952475BBA1005A9BFA /* KeychainIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DC88912475BA5F005A9BFA /* KeychainIntegrationTests.swift */; };
 		32E7115B2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115C2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115E2336B90800018E15 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0A22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift */; };
@@ -478,6 +481,7 @@
 		32C1ED1C224C85820063E91D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/Main.storyboard; sourceTree = "<group>"; };
 		32C1ED1D224C85890063E91D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/ValetSecureElementTestMain.storyboard; sourceTree = "<group>"; };
 		32DC88842475111D005A9BFA /* MigratableKeyValuePair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratableKeyValuePair.swift; sourceTree = "<group>"; };
+		32DC88912475BA5F005A9BFA /* KeychainIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainIntegrationTests.swift; sourceTree = "<group>"; };
 		371150A51E2962D8004A45D4 /* Valet iOS Test Host App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Valet iOS Test Host App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		371150A71E2962D8004A45D4 /* ValetIOSTestHostAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValetIOSTestHostAppDelegate.swift; sourceTree = "<group>"; };
 		371150A91E2962D8004A45D4 /* ValetIOSTestHostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValetIOSTestHostViewController.swift; sourceTree = "<group>"; };
@@ -612,6 +616,7 @@
 				1612FCFE22A9C95400FC1142 /* MacTests.swift */,
 				1612FCFF22A9C95400FC1142 /* SecItemTests.swift */,
 				1612FD0022A9C95400FC1142 /* CloudIntegrationTests.swift */,
+				32DC88912475BA5F005A9BFA /* KeychainIntegrationTests.swift */,
 				1612FD0122A9C95400FC1142 /* BackwardsCompatibilityTests */,
 				1612FD0622A9C95400FC1142 /* SinglePromptSecureEnclaveIntegrationTests.swift */,
 				1612FD0722A9C95400FC1142 /* ValetIntegrationTests.swift */,
@@ -1591,6 +1596,7 @@
 			files = (
 				1612FD1322A9C95500FC1142 /* SecItemTests.swift in Sources */,
 				1612FD3122A9C95500FC1142 /* SecureEnclaveTests.swift in Sources */,
+				32DC88952475BBA1005A9BFA /* KeychainIntegrationTests.swift in Sources */,
 				167E251223D6328E00889121 /* ConfigurationTests.swift in Sources */,
 				167E24F123D4B89800889121 /* SinglePromptSecureEnclaveIntegrationTests.swift in Sources */,
 				169E9A6C23D181DC001B69F5 /* VALValetTests.m in Sources */,
@@ -1726,6 +1732,7 @@
 				1612FD2C22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift in Sources */,
 				169E9A6723D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m in Sources */,
 				1612FD2622A9C95500FC1142 /* ValetIntegrationTests.swift in Sources */,
+				32DC88932475BB9F005A9BFA /* KeychainIntegrationTests.swift in Sources */,
 				1612FD2022A9C95500FC1142 /* ValetBackwardsCompatibilityTests.swift in Sources */,
 				169E9A6D23D181DC001B69F5 /* VALSecureEnclaveValetTests.m in Sources */,
 				167E251023D6328E00889121 /* ConfigurationTests.swift in Sources */,
@@ -1755,6 +1762,7 @@
 				167E250323D624EF00889121 /* MigrationErrorTests.swift in Sources */,
 				1612FD2D22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift in Sources */,
 				169E9A6823D181DC001B69F5 /* VALSinglePromptSecureEnclaveValetTests.m in Sources */,
+				32DC88942475BBA1005A9BFA /* KeychainIntegrationTests.swift in Sources */,
 				169E9A6E23D181DC001B69F5 /* VALSecureEnclaveValetTests.m in Sources */,
 				169E9A6B23D181DC001B69F5 /* VALValetTests.m in Sources */,
 				1612FD2722A9C95500FC1142 /* ValetIntegrationTests.swift in Sources */,


### PR DESCRIPTION
This PR resolves #226 by adding the ability to `compactMap` over key:value pairs as they are being migrated.

I do not intend to merge this PR prior to the release of Valet 4.0.