### PR TITLE
Create 'Changing an Accessibility Value After Persisting Data' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ VALValet *const myNewValet = [VALValet valetWithExplicitlySetIdentifier:@"Druidi
 [myNewValet migrateObjectsFrom:myOldValet removeOnCompletion:true error:nil];
 ```
 
-The Valet type, identifier, accessibility value, and initializer chosen to create a Valet are combined to create a sandbox within the keychain. This behavior ensures that different Valets can not read or write one another's key:value pairs. If you change a Valet's accessibility after persisting key:value pairs, you must migrate the key:values pairs from the Valet with the no-longer-desired accessibility to the Valet with the desired accessibility to avoid data loss.
+The Valet type, identifier, accessibility value, and initializer chosen to create a Valet are combined to create a sandbox within the keychain. This behavior ensures that different Valets can not read or write one another's key:value pairs. If you change a Valet's accessibility after persisting key:value pairs, you must migrate the key:value pairs from the Valet with the no-longer-desired accessibility to the Valet with the desired accessibility to avoid data loss.
 
 ### Reading and Writing
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ Mac apps signed with a developer ID may see their Valet’s identifier [shown to
 
 The Accessibility enum is used to determine when your secrets can be accessed. It’s a good idea to use the strictest accessibility possible that will allow your app to function. For example, if your app does not run in the background you will want to ensure the secrets can only be read when the phone is unlocked by using `.whenUnlocked` or `.whenUnlockedThisDeviceOnly`.
 
+#### Changing an Accessibility Value After Persisting Data
+
+```swift
+let myOldValet = Valet.valet(withExplicitlySet: Identifier(nonEmpty: "Druidia")!, accessibility: .whenUnlocked)
+let myNewValet = Valet.valet(withExplicitlySet: Identifier(nonEmpty: "Druidia")!, accessibility: .afterFirstUnlock)
+try? myNewValet.migrateObjects(from: myOldValet, removeOnCompletion: true)
+```
+
+```objc
+VALValet *const myOldValet = [VALValet valetWithExplicitlySetIdentifier:@"Druidia" accessibility:VALAccessibilityWhenUnlocked];
+VALValet *const myNewValet = [VALValet valetWithExplicitlySetIdentifier:@"Druidia" accessibility:VALAccessibilityAfterFirstUnlock];
+[myNewValet migrateObjectsFrom:myOldValet removeOnCompletion:true error:nil];
+```
+
+The Valet type, identifier, accessibility value, and initializer chosen to create a Valet are combined to create a sandbox within the keychain. This behavior ensures that different Valets can not read or write one another's key:value pairs. If you change a Valet's accessibility after persisting key:value pairs, you must migrate the key:values pairs from the Valet with the no-longer-desired accessibility to the Valet with the desired accessibility to avoid data loss.
+
 ### Reading and Writing
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The identifier you choose for your Valet is used to create a sandbox for the dat
 #### Choosing a User-friendly Identifier on macOS
 
 ```swift
-let mySecureEnclaveValet = Valet.valet(withExplicitlySet: Identifier(nonEmpty: "Druidia")!, accessibility: .whenUnlocked)
+let myValet = Valet.valet(withExplicitlySet: Identifier(nonEmpty: "Druidia")!, accessibility: .whenUnlocked)
 ```
 
 ```objc


### PR DESCRIPTION
Hopefully this section will help our customers avoid the trap laid bare in #231. I think being more explicit about the Valet sandboxing behavior earlier in the README is a good thing as well. Prior to this PR, the sandboxing behavior was acknowledged but pretty buried.

cc @macrossyun please let me know if this is clear.

I also fixed a copy/paste issue in the README while I was here: we were using `mySecureEnclaveValet` in an example before we'd discussed what a Secure Enclave Valet was.