### PR TITLE
Get watchOS tests running locally

### DIFF
--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -177,6 +177,19 @@
 		16DF6B0D204B496800F8E0A4 /* Valet watchOS Test Host App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 16DF6AF3204B496800F8E0A4 /* Valet watchOS Test Host App.app */; };
 		16DF6B1F204B4DA600F8E0A4 /* Valet.framework in Resources */ = {isa = PBXBuildFile; fileRef = 16DF6ADA204B45EB00F8E0A4 /* Valet.framework */; };
 		3251BD06224C865E0007453B /* XCTest.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 16D77541215BFC1D004F060C /* XCTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		32644C24248313210037F517 /* SecItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FCFF22A9C95400FC1142 /* SecItemTests.swift */; };
+		32644C25248313210037F517 /* CloudIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0022A9C95400FC1142 /* CloudIntegrationTests.swift */; };
+		32644C2A248313210037F517 /* SinglePromptSecureEnclaveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0622A9C95400FC1142 /* SinglePromptSecureEnclaveIntegrationTests.swift */; };
+		32644C2B248313210037F517 /* ValetIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0722A9C95400FC1142 /* ValetIntegrationTests.swift */; };
+		32644C2C248313210037F517 /* SecureEnclaveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0822A9C95400FC1142 /* SecureEnclaveIntegrationTests.swift */; };
+		32644C2D248313210037F517 /* CloudAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250623D62CAA00889121 /* CloudAccessibilityTests.swift */; };
+		32644C2E248313210037F517 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0A22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift */; };
+		32644C2F248313210037F517 /* SecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0B22A9C95500FC1142 /* SecureEnclaveTests.swift */; };
+		32644C30248313210037F517 /* CloudTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0C22A9C95500FC1142 /* CloudTests.swift */; };
+		32644C31248313210037F517 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250F23D6328E00889121 /* ConfigurationTests.swift */; };
+		32644C32248313210037F517 /* ValetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0D22A9C95500FC1142 /* ValetTests.swift */; };
+		32644C33248313210037F517 /* MigrationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E250123D624EF00889121 /* MigrationErrorTests.swift */; };
+		32644C34248313210037F517 /* KeychainErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167E24FD23D6235000889121 /* KeychainErrorTests.swift */; };
 		32E7115B2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115C2336B03800018E15 /* SinglePromptSecureEnclaveValet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD7922A9CAAB00FC1142 /* SinglePromptSecureEnclaveValet.swift */; };
 		32E7115E2336B90800018E15 /* SinglePromptSecureEnclaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1612FD0A22A9C95500FC1142 /* SinglePromptSecureEnclaveTests.swift */; };
@@ -1612,6 +1625,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32644C24248313210037F517 /* SecItemTests.swift in Sources */,
+				32644C25248313210037F517 /* CloudIntegrationTests.swift in Sources */,
+				32644C2A248313210037F517 /* SinglePromptSecureEnclaveIntegrationTests.swift in Sources */,
+				32644C2B248313210037F517 /* ValetIntegrationTests.swift in Sources */,
+				32644C2C248313210037F517 /* SecureEnclaveIntegrationTests.swift in Sources */,
+				32644C2D248313210037F517 /* CloudAccessibilityTests.swift in Sources */,
+				32644C2E248313210037F517 /* SinglePromptSecureEnclaveTests.swift in Sources */,
+				32644C2F248313210037F517 /* SecureEnclaveTests.swift in Sources */,
+				32644C30248313210037F517 /* CloudTests.swift in Sources */,
+				32644C31248313210037F517 /* ConfigurationTests.swift in Sources */,
+				32644C32248313210037F517 /* ValetTests.swift in Sources */,
+				32644C33248313210037F517 /* MigrationErrorTests.swift in Sources */,
+				32644C34248313210037F517 /* KeychainErrorTests.swift in Sources */,
 				16DF6B07204B496800F8E0A4 /* ExtensionDelegate.swift in Sources */,
 				16DF6B05204B496800F8E0A4 /* InterfaceController.swift in Sources */,
 			);


### PR DESCRIPTION
This PR updates `XCTest-watchOS` to point at https://github.com/dfed/XCTest-watchOS/pull/4, and adds all of our test files to the watchOS app. All tests pass:
```
Executing KeychainErrorTests.test_description_createsHumanReadableDescription
- PASSED: KeychainErrorTests.test_description_createsHumanReadableDescription
Executing KeychainErrorTests.test_initStatus_createsNotFoundErrorFrom_errSecItemNotFound
- PASSED: KeychainErrorTests.test_initStatus_createsNotFoundErrorFrom_errSecItemNotFound
Executing KeychainErrorTests.test_initStatus_createsUserCancelledFrom_errSecUserCanceled
- PASSED: KeychainErrorTests.test_initStatus_createsUserCancelledFrom_errSecUserCanceled
Executing KeychainErrorTests.test_initStatus_createsUserCancelledFrom_errSecAuthFailed
- PASSED: KeychainErrorTests.test_initStatus_createsUserCancelledFrom_errSecAuthFailed
Executing KeychainErrorTests.test_initStatus_createsMissingEntitlementFrom_errSecMissingEntitlement
- PASSED: KeychainErrorTests.test_initStatus_createsMissingEntitlementFrom_errSecMissingEntitlement
Executing KeychainErrorTests.test_initStatus_createsCouldNotAccessKeychainFrom_errSecNotAvailable
- PASSED: KeychainErrorTests.test_initStatus_createsCouldNotAccessKeychainFrom_errSecNotAvailable
Executing MigrationErrorTests.test_description_createsHumanReadableDescription
- PASSED: MigrationErrorTests.test_description_createsHumanReadableDescription
Executing ValetTests.test_init_createsCorrectBackingService
- PASSED: ValetTests.test_init_createsCorrectBackingService
Executing ValetTests.test_init_createsCorrectBackingService_sharedAccess
- PASSED: ValetTests.test_init_createsCorrectBackingService_sharedAccess
Executing ValetTests.test_init_createsCorrectBackingService_cloud
- PASSED: ValetTests.test_init_createsCorrectBackingService_cloud
Executing ValetTests.test_init_createsCorrectBackingService_cloudSharedAccess
- PASSED: ValetTests.test_init_createsCorrectBackingService_cloudSharedAccess
Executing ValetTests.test_valetsWithSameConfiguration_areEqual
- PASSED: ValetTests.test_valetsWithSameConfiguration_areEqual
Executing ValetTests.test_differentValetFlavorsWithEquivalentConfiguration_areNotEqual
- PASSED: ValetTests.test_differentValetFlavorsWithEquivalentConfiguration_areNotEqual
Executing ValetTests.test_valetsWithDifferingIdentifier_areNotEqual
- PASSED: ValetTests.test_valetsWithDifferingIdentifier_areNotEqual
Executing ValetTests.test_valetsWithDifferingAccessibility_areNotEqual
- PASSED: ValetTests.test_valetsWithDifferingAccessibility_areNotEqual
Executing ValetTests.test_migrateObjectsMatching_failsForBadQueries
- PASSED: ValetTests.test_migrateObjectsMatching_failsForBadQueries
Executing ConfigurationTests.test_description_valet_mirrorsLegacyName
- PASSED: ConfigurationTests.test_description_valet_mirrorsLegacyName
Executing ConfigurationTests.test_description_iCloud_mirrorsLegacyName
- PASSED: ConfigurationTests.test_description_iCloud_mirrorsLegacyName
Executing ConfigurationTests.test_description_secureEnclave_mirrorsLegacyName
- PASSED: ConfigurationTests.test_description_secureEnclave_mirrorsLegacyName
Executing ConfigurationTests.test_description_singlePromptSecureEnclave_mirrorsLegacyName
- PASSED: ConfigurationTests.test_description_singlePromptSecureEnclave_mirrorsLegacyName
Executing ConfigurationTests.test_accessibility_valet_returnsPassedInAccessibility
- PASSED: ConfigurationTests.test_accessibility_valet_returnsPassedInAccessibility
Executing ConfigurationTests.test_accessibility_iCloud_returnsPassedInAccessibility
- PASSED: ConfigurationTests.test_accessibility_iCloud_returnsPassedInAccessibility
Executing ConfigurationTests.test_accessibility_secureEnclave_returnsWhenPassCodeSetThisDeviceOnly
- PASSED: ConfigurationTests.test_accessibility_secureEnclave_returnsWhenPassCodeSetThisDeviceOnly
Executing ConfigurationTests.test_accessibility_singlePromptSecureEnclave_returnsWhenPassCodeSetThisDeviceOnly
- PASSED: ConfigurationTests.test_accessibility_singlePromptSecureEnclave_returnsWhenPassCodeSetThisDeviceOnly
Executing ConfigurationTests.test_prettyDescription_valet_isHumanReadable
- PASSED: ConfigurationTests.test_prettyDescription_valet_isHumanReadable
Executing ConfigurationTests.test_prettyDescription_iCloud_isHumanReadable
- PASSED: ConfigurationTests.test_prettyDescription_iCloud_isHumanReadable
Executing ConfigurationTests.test_prettyDescription_secureEnclave_isHumanReadable
- PASSED: ConfigurationTests.test_prettyDescription_secureEnclave_isHumanReadable
Executing ConfigurationTests.test_prettyDescription_singlePromptSecureEnclave_isHumanReadable
- PASSED: ConfigurationTests.test_prettyDescription_singlePromptSecureEnclave_isHumanReadable
Executing CloudTests.test_synchronizableValet_isDistinctFromVanillaValetWithEqualConfiguration
- PASSED: CloudTests.test_synchronizableValet_isDistinctFromVanillaValetWithEqualConfiguration
Executing CloudTests.test_synchronizableValets_withEquivalentConfigurationsAreEqual
- PASSED: CloudTests.test_synchronizableValets_withEquivalentConfigurationsAreEqual
Executing SecureEnclaveTests.test_init_createsCorrectBackingService
- PASSED: SecureEnclaveTests.test_init_createsCorrectBackingService
Executing SecureEnclaveTests.test_init_createsCorrectBackingService_sharedAccess
- PASSED: SecureEnclaveTests.test_init_createsCorrectBackingService_sharedAccess
Executing SecureEnclaveTests.test_secureEnclaveValetsWithEqualConfiguration_haveEqualPointers
- PASSED: SecureEnclaveTests.test_secureEnclaveValetsWithEqualConfiguration_haveEqualPointers
Executing CloudAccessibilityTests.test_description_mirrorsAccessibilityCounterpartDescription
- PASSED: CloudAccessibilityTests.test_description_mirrorsAccessibilityCounterpartDescription
Executing CloudAccessibilityTests.test_secAccessibilityAttribute_mirrorsAccessibilityCounterpartSecAccessibilityAttribute
- PASSED: CloudAccessibilityTests.test_secAccessibilityAttribute_mirrorsAccessibilityCounterpartSecAccessibilityAttribute
Executing SecureEnclaveIntegrationTests.test_canAccessKeychain
- PASSED: SecureEnclaveIntegrationTests.test_canAccessKeychain
Executing SecureEnclaveIntegrationTests.test_canAccessKeychain_sharedAccessGroup
- PASSED: SecureEnclaveIntegrationTests.test_canAccessKeychain_sharedAccessGroup
Executing SecureEnclaveIntegrationTests.test_canAccessKeychain_sharedAppGroup
- PASSED: SecureEnclaveIntegrationTests.test_canAccessKeychain_sharedAppGroup
Executing SecureEnclaveIntegrationTests.test_secureEnclaveValetsWithEqualConfiguration_canAccessSameDataAndReturnError:
- PASSED: SecureEnclaveIntegrationTests.test_secureEnclaveValetsWithEqualConfiguration_canAccessSameDataAndReturnError:
Executing SecureEnclaveIntegrationTests.test_secureEnclaveValetsWithDifferingAccessControl_canNotAccessSameDataAndReturnError:
- PASSED: SecureEnclaveIntegrationTests.test_secureEnclaveValetsWithDifferingAccessControl_canNotAccessSameDataAndReturnError:
Executing SecureEnclaveIntegrationTests.test_migrateObjectsMatchingQuery_failsForBadQuery
- PASSED: SecureEnclaveIntegrationTests.test_migrateObjectsMatchingQuery_failsForBadQuery
Executing SecureEnclaveIntegrationTests.test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclaveAndReturnError:
- PASSED: SecureEnclaveIntegrationTests.test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclaveAndReturnError:
Executing SecureEnclaveIntegrationTests.test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCallsAndReturnError:
- PASSED: SecureEnclaveIntegrationTests.test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCallsAndReturnError:
Executing ValetIntegrationTests.test_canAccessKeychain
- PASSED: ValetIntegrationTests.test_canAccessKeychain
Executing ValetIntegrationTests.test_init_createsCorrectBackingService
- PASSED: ValetIntegrationTests.test_init_createsCorrectBackingService
Executing ValetIntegrationTests.test_init_createsCorrectBackingService_sharedAccess
- PASSED: ValetIntegrationTests.test_init_createsCorrectBackingService_sharedAccess
Executing ValetIntegrationTests.test_init_createsCorrectBackingService_cloud
- PASSED: ValetIntegrationTests.test_init_createsCorrectBackingService_cloud
Executing ValetIntegrationTests.test_init_createsCorrectBackingService_cloudSharedAccess
- PASSED: ValetIntegrationTests.test_init_createsCorrectBackingService_cloudSharedAccess
Executing ValetIntegrationTests.test_canAccessKeychain_sharedAccessGroup
- PASSED: ValetIntegrationTests.test_canAccessKeychain_sharedAccessGroup
Executing ValetIntegrationTests.test_canAccessKeychain_sharedAppGroup
- PASSED: ValetIntegrationTests.test_canAccessKeychain_sharedAppGroup
Executing ValetIntegrationTests.test_canAccessKeychain_Performance
Test Case 'test_canAccessKeychain_Performance()' measured [Time, seconds] average: 0.001, relative standard deviation: 67.963%, values: [0.002179, 0.000587, 0.000577, 0.000573, 0.000587, 0.000582, 0.000575, 0.000577, 0.000605, 0.000585]
- PASSED: ValetIntegrationTests.test_canAccessKeychain_Performance
Executing ValetIntegrationTests.test_containsObjectForKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_containsObjectForKeyAndReturnError:
Executing ValetIntegrationTests.test_allKeysAndReturnError:
- PASSED: ValetIntegrationTests.test_allKeysAndReturnError:
Executing ValetIntegrationTests.test_allKeys_doesNotReflectValetImplementationDetailsAndReturnError:
- PASSED: ValetIntegrationTests.test_allKeys_doesNotReflectValetImplementationDetailsAndReturnError:
Executing ValetIntegrationTests.test_allKeys_remainsUntouchedForUnequalValetsAndReturnError:
- PASSED: ValetIntegrationTests.test_allKeys_remainsUntouchedForUnequalValetsAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_throwsItemNotFoundForKeyWithNoValueAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_throwsItemNotFoundForKeyWithNoValueAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_retrievesStringForValidKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_retrievesStringForValidKeyAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_equivalentValetsCanAccessSameDataAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_equivalentValetsCanAccessSameDataAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_withDifferingIdentifier_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_withDifferingIdentifier_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_withDifferingAccessibility_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_withDifferingAccessibility_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_canReadItemsWithout_kSecUseDataProtectionKeychain_when_kSecUseDataProtectionKeychain_isSetToTrueInKeychainQueryAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_canReadItemsWithout_kSecUseDataProtectionKeychain_when_kSecUseDataProtectionKeychain_isSetToTrueInKeychainQueryAndReturnError:
Executing ValetIntegrationTests.test_setStringForKey_successfullyUpdatesExistingKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_setStringForKey_successfullyUpdatesExistingKeyAndReturnError:
Executing ValetIntegrationTests.test_setStringForKey_throwsEmptyValueOnInvalidValueAndReturnError:
- PASSED: ValetIntegrationTests.test_setStringForKey_throwsEmptyValueOnInvalidValueAndReturnError:
Executing ValetIntegrationTests.test_setStringForKey_throwsEmptyKeyOnInvalidKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_setStringForKey_throwsEmptyKeyOnInvalidKeyAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_throwsItemNotFoundWhenNoObjectExistsAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_throwsItemNotFoundWhenNoObjectExistsAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_succeedsForValidKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_succeedsForValidKeyAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_equivalentValetsCanAccessSameDataAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_equivalentValetsCanAccessSameDataAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_withDifferingIdentifier_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_withDifferingIdentifier_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_withDifferingAccessibility_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_withDifferingAccessibility_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFoundAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFoundAndReturnError:
Executing ValetIntegrationTests.test_setObjectForKey_successfullyUpdatesExistingKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_setObjectForKey_successfullyUpdatesExistingKeyAndReturnError:
Executing ValetIntegrationTests.test_setObjectForKey_throwsEmptyKeyOnInvalidKeyAndReturnError:
- PASSED: ValetIntegrationTests.test_setObjectForKey_throwsEmptyKeyOnInvalidKeyAndReturnError:
Executing ValetIntegrationTests.test_setObjectForKey_throwsEmptyValueOnEmptyDataAndReturnError:
- PASSED: ValetIntegrationTests.test_setObjectForKey_throwsEmptyValueOnEmptyDataAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_succeedsForDataBackedByStringAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_succeedsForDataBackedByStringAndReturnError:
Executing ValetIntegrationTests.test_stringForKey_failsForDataNotBackedByStringAndReturnError:
- PASSED: ValetIntegrationTests.test_stringForKey_failsForDataNotBackedByStringAndReturnError:
Executing ValetIntegrationTests.test_objectForKey_succeedsForStringsAndReturnError:
- PASSED: ValetIntegrationTests.test_objectForKey_succeedsForStringsAndReturnError:
Executing ValetIntegrationTests.test_concurrentSetAndRemoveOperations
- PASSED: ValetIntegrationTests.test_concurrentSetAndRemoveOperations
Executing ValetIntegrationTests.test_stringForKey_canReadDataWrittenOnAnotherThread
- PASSED: ValetIntegrationTests.test_stringForKey_canReadDataWrittenOnAnotherThread
Executing ValetIntegrationTests.test_stringForKey_canReadDataWrittenToValetAllocatedOnDifferentThread
- PASSED: ValetIntegrationTests.test_stringForKey_canReadDataWrittenToValetAllocatedOnDifferentThread
Executing ValetIntegrationTests.test_removeObjectForKey_succeedsWhenKeyIsNotPresentAndReturnError:
- PASSED: ValetIntegrationTests.test_removeObjectForKey_succeedsWhenKeyIsNotPresentAndReturnError:
Executing ValetIntegrationTests.test_removeObjectForKey_succeedsWhenKeyIsPresentAndReturnError:
- PASSED: ValetIntegrationTests.test_removeObjectForKey_succeedsWhenKeyIsPresentAndReturnError:
Executing ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingAccessibilityAndReturnError:
- PASSED: ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingAccessibilityAndReturnError:
Executing ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingIdentifierAndReturnError:
- PASSED: ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingIdentifierAndReturnError:
Executing ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingClassesAndReturnError:
- PASSED: ValetIntegrationTests.test_removeObjectForKey_isDistinctForDifferingClassesAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsMatching_failsIfQueryHasNoInputClassAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsMatching_failsIfQueryHasNoInputClassAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsMatching_failsIfNoItemsMatchQueryAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsMatching_failsIfNoItemsMatchQueryAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsMatching_bailsOutIfConflictExistsToMigrateAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsMatching_bailsOutIfConflictExistsToMigrateAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsMatching_withAccountNameAsData_doesNotRaiseExceptionAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsMatching_withAccountNameAsData_doesNotRaiseExceptionAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsFromValet_migratesSingleKeyValuePairSuccessfullyAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsFromValet_migratesSingleKeyValuePairSuccessfullyAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsFromValet_migratesMultipleKeyValuePairsSuccessfullyAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsFromValet_migratesMultipleKeyValuePairsSuccessfullyAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsFromValet_removesOnCompletionWhenRequestedAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsFromValet_removesOnCompletionWhenRequestedAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsFromValet_leavesKeychainUntouchedWhenConflictsExistAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsFromValet_leavesKeychainUntouchedWhenConflictsExistAndReturnError:
Executing ValetIntegrationTests.test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenBothValetsHavePreviouslyCalled_canAccessKeychainAndReturnError:
- PASSED: ValetIntegrationTests.test_migrateObjectsFromValetRemoveOnCompletion_migratesDataSuccessfullyWhenBothValetsHavePreviouslyCalled_canAccessKeychainAndReturnError:
Executing CloudIntegrationTests.test_synchronizableValet_isDistinctFromVanillaValetWithEqualConfigurationAndReturnError:
- PASSED: CloudIntegrationTests.test_synchronizableValet_isDistinctFromVanillaValetWithEqualConfigurationAndReturnError:
Executing CloudIntegrationTests.test_setStringForKeyAndReturnError:
- PASSED: CloudIntegrationTests.test_setStringForKeyAndReturnError:
Executing CloudIntegrationTests.test_removeObjectForKeyAndReturnError:
- PASSED: CloudIntegrationTests.test_removeObjectForKeyAndReturnError:
Executing CloudIntegrationTests.test_canAccessKeychain
- PASSED: CloudIntegrationTests.test_canAccessKeychain
ALL TESTS PASSED
```