### PR TITLE
Remove unnecessary header comments

### DIFF
--- a/Sources/LegacyValet/Public/LegacyValet.h
+++ b/Sources/LegacyValet/Public/LegacyValet.h
@@ -1,7 +1,3 @@
-//
-//  ValetDefines.h
-//  Valet
-//
 //  Created by Dan Federman on 6/6/19.
 //  Copyright 2019 Square, Inc.
 //

--- a/Sources/LegacyValet/Public/VALLegacySecureEnclaveValet.h
+++ b/Sources/LegacyValet/Public/VALLegacySecureEnclaveValet.h
@@ -1,7 +1,3 @@
-//
-//  VALLegacySecureEnclaveValet.h
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/Public/VALLegacySinglePromptSecureEnclaveValet.h
+++ b/Sources/LegacyValet/Public/VALLegacySinglePromptSecureEnclaveValet.h
@@ -1,7 +1,3 @@
-//
-//  VALLegacySinglePromptSecureEnclaveValet.h
-//  Valet
-//
 //  Created by Dan Federman on 1/23/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/LegacyValet/Public/VALLegacyValet.h
+++ b/Sources/LegacyValet/Public/VALLegacyValet.h
@@ -1,7 +1,3 @@
-//
-//  VALValet.h
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/Public/VALSynchronizableValet.h
+++ b/Sources/LegacyValet/Public/VALSynchronizableValet.h
@@ -1,7 +1,3 @@
-//
-//  VALSynchronizableValet.h
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/VALLegacySecureEnclaveValet.m
+++ b/Sources/LegacyValet/VALLegacySecureEnclaveValet.m
@@ -1,7 +1,3 @@
-//
-//  VALLegacySecureEnclaveValet.m
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/VALLegacySecureEnclaveValet_Protected.h
+++ b/Sources/LegacyValet/VALLegacySecureEnclaveValet_Protected.h
@@ -1,7 +1,3 @@
-//
-//  VALLegacySecureEnclaveValet_Protected.h
-//  Valet
-//
 //  Created by Dan Federman on 1/23/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/LegacyValet/VALLegacySinglePromptSecureEnclaveValet.m
+++ b/Sources/LegacyValet/VALLegacySinglePromptSecureEnclaveValet.m
@@ -1,7 +1,3 @@
-//
-//  VALLegacySinglePromptSecureEnclaveValet.m
-//  Valet
-//
 //  Created by Dan Federman on 1/23/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/LegacyValet/VALLegacyValet.m
+++ b/Sources/LegacyValet/VALLegacyValet.m
@@ -1,7 +1,3 @@
-//
-//  VALLegacyValet.m
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/VALLegacyValet_Protected.h
+++ b/Sources/LegacyValet/VALLegacyValet_Protected.h
@@ -1,7 +1,3 @@
-//
-//  VALLegacyValet_Protected.h
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/VALSynchronizableValet.m
+++ b/Sources/LegacyValet/VALSynchronizableValet.m
@@ -1,7 +1,3 @@
-//
-//  VALSynchronizableValet.m
-//  Valet
-//
 //  Created by Dan Federman on 3/16/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/LegacyValet/ValetDefines.h
+++ b/Sources/LegacyValet/ValetDefines.h
@@ -1,7 +1,3 @@
-//
-//  ValetDefines.h
-//  Valet
-//
 //  Created by Dan Federman on 2/11/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/Valet/Accessibility.swift
+++ b/Sources/Valet/Accessibility.swift
@@ -1,7 +1,3 @@
-//
-//  Accessibility.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/CloudAccessibility.swift
+++ b/Sources/Valet/CloudAccessibility.swift
@@ -1,7 +1,3 @@
-//
-//  CloudAccessibility.swift
-//  Valet
-//
 //  Created by Dan Federman on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Identifier.swift
+++ b/Sources/Valet/Identifier.swift
@@ -1,7 +1,3 @@
-//
-//  Identifier.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Internal/Configuration.swift
+++ b/Sources/Valet/Internal/Configuration.swift
@@ -1,7 +1,3 @@
-//
-//  Configuration.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Internal/Keychain.swift
+++ b/Sources/Valet/Internal/Keychain.swift
@@ -1,7 +1,3 @@
-//
-//  Keychain.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Internal/SecItem.swift
+++ b/Sources/Valet/Internal/SecItem.swift
@@ -1,7 +1,3 @@
-//
-//  SecItem.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -1,7 +1,3 @@
-//
-//  Service.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/KeychainError.swift
+++ b/Sources/Valet/KeychainError.swift
@@ -1,7 +1,3 @@
-//
-//  KeychainError.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square Inc.
 //

--- a/Sources/Valet/MigratableKeyValuePair.swift
+++ b/Sources/Valet/MigratableKeyValuePair.swift
@@ -1,7 +1,3 @@
-//
-//  MigratableKeyValuePair.swift
-//  Valet
-//
 //  Created by Dan Federman on 5/20/20.
 //  Copyright © 2020 Square, Inc.
 //

--- a/Sources/Valet/MigrationError.swift
+++ b/Sources/Valet/MigrationError.swift
@@ -1,7 +1,3 @@
-//
-//  MigrationError.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square Inc.
 //

--- a/Sources/Valet/SecureEnclave.swift
+++ b/Sources/Valet/SecureEnclave.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclave.swift
-//  Valet
-//
 //  Created by Dan Federman on 9/19/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/SecureEnclaveAccessControl.swift
+++ b/Sources/Valet/SecureEnclaveAccessControl.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveAccessControl.swift
-//  Valet
-//
 //  Created by Dan Federman on 9/18/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveValet.swift
-//  Valet
-//
 //  Created by Dan Federman on 9/18/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/SharedGroupIdentifier.swift
+++ b/Sources/Valet/SharedGroupIdentifier.swift
@@ -1,7 +1,3 @@
-//
-//  SharedGroupIdentifier.swift
-//  Valet
-//
 //  Created by Dan Federman on 2/25/20.
 //  Copyright © 2020 Square, Inc.
 //

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -1,7 +1,3 @@
-//
-//  SinglePromptSecureEnclaveValet.swift
-//  Valet
-//
 //  Created by Dan Federman on 9/19/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Sources/Valet/Valet.h
+++ b/Sources/Valet/Valet.h
@@ -1,7 +1,3 @@
-//
-//  Valet.h
-//  Valet
-//
 //  Created by Dan Federman on 1/21/15.
 //  Copyright 2015 Square, Inc.
 //

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -1,7 +1,3 @@
-//
-//  Valet.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SecureEnclaveBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SecureEnclaveBackwardsCompatibilityTests.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveBackwardsCompatibilityTests.swift
-//  Valet
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SinglePromptSecureEnclaveBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SinglePromptSecureEnclaveBackwardsCompatibilityTests.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveSinglePromptBackwardsCompatibilityTests.swift
-//  Valet
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
@@ -1,7 +1,3 @@
-//
-//  SynchronizableBackwardsCompatibilityTests.swift
-//  Valet
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -1,7 +1,3 @@
-//
-//  ValetBackwardsCompatibilityTests.swift
-//  Valet
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -1,7 +1,3 @@
-//
-//  SynchronizableTests.swift
-//  Valet iOS Tests
-//
 //  Created by Dan Federman and Eric Muller on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
@@ -1,7 +1,3 @@
-//
-//  KeychainIntegrationTests.swift
-//  Valet iOS
-//
 //  Created by Dan Federman on 5/20/20.
 //  Copyright © 2020 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -1,7 +1,3 @@
-//
-//  MacTests.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/SecItemTests.swift
+++ b/Tests/ValetIntegrationTests/SecItemTests.swift
@@ -1,7 +1,3 @@
-//
-//  SecItemTests.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/16/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveTests.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -1,7 +1,3 @@
-//
-//  SinglePromptSecureEnclaveTests.swift
-//  Valet
-//
 //  Created by Eric Muller on 10/1/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -1,7 +1,3 @@
-//
-//  ValetTests.swift
-//  Valet
-//
 //  Created by Eric Muller on 4/25/16.
 //  Copyright © 2016 Square, Inc.
 //

--- a/Tests/ValetTests/CloudTests.swift
+++ b/Tests/ValetTests/CloudTests.swift
@@ -1,7 +1,3 @@
-//
-//  SynchronizableTests.swift
-//  Valet iOS Tests
-//
 //  Created by Dan Federman and Eric Muller on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetTests/SecureEnclaveTests.swift
+++ b/Tests/ValetTests/SecureEnclaveTests.swift
@@ -1,7 +1,3 @@
-//
-//  SecureEnclaveTests.swift
-//  Valet
-//
 //  Created by Dan Federman and Eric Muller on 9/17/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
@@ -1,7 +1,3 @@
-//
-//  SinglePromptSecureEnclaveTests.swift
-//  Valet
-//
 //  Created by Eric Muller on 10/1/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Tests/ValetTests/ValetTests.swift
+++ b/Tests/ValetTests/ValetTests.swift
@@ -1,7 +1,3 @@
-//
-//  ValetTests.swift
-//  Valet
-//
 //  Created by Eric Muller on 4/25/16.
 //  Copyright © 2016 Square, Inc.
 //

--- a/Valet iOS Test Host App/ValetIOSTestHostAppDelegate.swift
+++ b/Valet iOS Test Host App/ValetIOSTestHostAppDelegate.swift
@@ -1,7 +1,3 @@
-//
-//  AppDelegate.swift
-//  Valet iOS Test Host App
-//
 //  Created by Dan Federman on 1/13/17.
 //  Copyright 2017 Square, Inc.
 //

--- a/Valet iOS Test Host App/ValetIOSTestHostViewController.swift
+++ b/Valet iOS Test Host App/ValetIOSTestHostViewController.swift
@@ -1,7 +1,3 @@
-//
-//  ValetIOSTestHostViewController.swift
-//  Valet iOS Test Host App
-//
 //  Created by Dan Federman on 1/13/17.
 //  Copyright 2017 Square, Inc.
 //

--- a/Valet macOS Test Host App/AppDelegate.swift
+++ b/Valet macOS Test Host App/AppDelegate.swift
@@ -1,7 +1,3 @@
-//
-//  AppDelegate.swift
-//  Valet macOS Test Host App
-//
 //  Created by Dan Federman on 9/19/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Valet macOS Test Host App/ViewController.swift
+++ b/Valet macOS Test Host App/ViewController.swift
@@ -1,7 +1,3 @@
-//
-//  ViewController.swift
-//  Valet macOS Test Host App
-//
 //  Created by Dan Federman on 9/19/17.
 //  Copyright © 2017 Square, Inc.
 //

--- a/Valet tvOS Test Host App/AppDelegate.swift
+++ b/Valet tvOS Test Host App/AppDelegate.swift
@@ -1,7 +1,3 @@
-//
-//  AppDelegate.swift
-//  Valet tvOS Test Host App
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Valet tvOS Test Host App/ViewController.swift
+++ b/Valet tvOS Test Host App/ViewController.swift
@@ -1,7 +1,3 @@
-//
-//  ViewController.swift
-//  Valet tvOS Test Host App
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Valet watchOS Test Host App Extension/ExtensionDelegate.swift
+++ b/Valet watchOS Test Host App Extension/ExtensionDelegate.swift
@@ -1,7 +1,3 @@
-//
-//  ExtensionDelegate.swift
-//  Valet watchOS Test Host App Extension
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/Valet watchOS Test Host App Extension/InterfaceController.swift
+++ b/Valet watchOS Test Host App Extension/InterfaceController.swift
@@ -1,7 +1,3 @@
-//
-//  InterfaceController.swift
-//  Valet watchOS Test Host App Extension
-//
 //  Created by Dan Federman on 3/3/18.
 //  Copyright © 2018 Square, Inc.
 //

--- a/ValetTouchIDTest/ValetTouchIDTestAppDelegate.swift
+++ b/ValetTouchIDTest/ValetTouchIDTestAppDelegate.swift
@@ -1,7 +1,3 @@
-//
-//  ValetTouchIDTestAppDelegate.swift
-//  Valet
-//
 //  Created by Eric Muller on 4/20/16.
 //  Copyright © 2016 Square, Inc.
 //

--- a/ValetTouchIDTest/ValetTouchIDTestViewController.swift
+++ b/ValetTouchIDTest/ValetTouchIDTestViewController.swift
@@ -1,7 +1,3 @@
-//
-//  ValetTouchIDTestViewController.swift
-//  Valet
-//
 //  Created by Eric Muller on 4/20/16.
 //  Copyright © 2016 Square, Inc.
 //


### PR DESCRIPTION
No functional changes here. All this PR does is remove the comments at the top of the file that includes the name of the file and the target of the file. These comments aren't useful.

This PR was created by finding everything that matches the following and replacing it with the empty string:
```
//
//  .+
//  Valet.*
//
```