### PR TITLE
Use XCTSkipUnless

### DIFF
--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SecureEnclaveBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SecureEnclaveBackwardsCompatibilityTests.swift
@@ -29,9 +29,7 @@ extension SecureEnclaveIntegrationTests {
     @available (*, deprecated)
     func test_backwardsCompatibility_withLegacyValet() throws
     {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
 
         let deprecatedValet = VALLegacySecureEnclaveValet(identifier: valet.identifier.description)!
         XCTAssertTrue(deprecatedValet.setString(passcode, forKey: key))

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SinglePromptSecureEnclaveBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SinglePromptSecureEnclaveBackwardsCompatibilityTests.swift
@@ -30,9 +30,7 @@ extension SinglePromptSecureEnclaveIntegrationTests {
     @available (*, deprecated)
     func test_backwardsCompatibility_withLegacyValet() throws
     {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
 
         let deprecatedValet = VALLegacySinglePromptSecureEnclaveValet(identifier: valet().identifier.description)!
         XCTAssertTrue(deprecatedValet.setString(passcode, forKey: key))

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/SynchronizableBackwardsCompatibilityTests.swift
@@ -29,9 +29,7 @@ extension CloudIntegrationTests {
     // MARK: Backwards Compatibility
 
     func test_backwardsCompatibility_withLegacyValet() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let identifier = Identifier(nonEmpty: "BackwardsCompatibilityTest")!
         try Valet.iCloudCurrentAndLegacyPermutations(with: identifier).forEach { permutation, legacyValet in
@@ -43,9 +41,7 @@ extension CloudIntegrationTests {
     }
 
     func test_backwardsCompatibility_withSharedAccessGroupLegacyValet() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         try Valet.iCloudCurrentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -134,9 +134,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
     }
 
     func test_backwardsCompatibility_withLegacySharedAccessGroupValet() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         try Valet.currentAndLegacyPermutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation, legacyValet in
             legacyValet.setString(passcode, forKey: key)
 
@@ -169,9 +167,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
     }
 
     func test_migrateObjectsFromAlwaysAccessibleValet_forwardsCompatibility_withLegacySharedAccessGroupValet() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.groupIdentifier, accessibility: .always)!
         alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
 
@@ -181,9 +177,7 @@ class ValetBackwardsCompatibilityIntegrationTests: ValetIntegrationTests {
     }
 
     func test_migrateObjectsFromAlwaysAccessibleThisDeviceOnlyValet_forwardsCompatibility_withLegacySharedAccessGroupValet() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         let alwaysAccessibleLegacyValet = VALLegacyValet(sharedAccessGroupIdentifier: Valet.sharedAccessGroupIdentifier.groupIdentifier, accessibility: .alwaysThisDeviceOnly)!
         alwaysAccessibleLegacyValet.setString(passcode, forKey: key)
 

--- a/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/CloudIntegrationTests.swift
@@ -51,9 +51,7 @@ class CloudIntegrationTests: XCTestCase
     
     func test_synchronizableValet_isDistinctFromVanillaValetWithEqualConfiguration() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let identifier = Identifier(nonEmpty: "DistinctTest")!
         let vanillaValet = Valet.valet(with: identifier, accessibility: .afterFirstUnlock)

--- a/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/KeychainIntegrationTests.swift
@@ -27,9 +27,7 @@ import XCTest
 final class KeychainIntegrationTests: XCTestCase {
 
     func test_revertMigration_removesAllMigratedKeys() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()

--- a/Tests/ValetIntegrationTests/MacTests.swift
+++ b/Tests/ValetIntegrationTests/MacTests.swift
@@ -114,9 +114,7 @@ class ValetMacTests: XCTestCase
             XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
         }
 
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: true).forEach {
             XCTAssertEqual($0.baseKeychainQuery[kSecAttrService as String], explicitlySetIdentifier.description)
@@ -128,9 +126,7 @@ class ValetMacTests: XCTestCase
     }
 
     func test_withExplicitlySet_canAccessKeychain() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let explicitlySetIdentifier = Identifier(nonEmpty: #function)!
         try Valet.permutations(withExplictlySet: explicitlySetIdentifier, shared: false).forEach {
@@ -160,9 +156,7 @@ class ValetMacTests: XCTestCase
     }
 
     func test_withExplicitlySet_canReadWrittenString() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let explicitlySetIdentifier = Identifier(nonEmpty: #function)!
         let key = "key"
@@ -253,9 +247,7 @@ class ValetMacTests: XCTestCase
     // MARK: Migration - PreCatalina
 
     func test_migrateObjectsFromPreCatalina_migratesDataWrittenPreCatalina() throws {
-        guard #available(macOS 10.15, *) else {
-            return
-        }
+        try XCTSkipUnless(isMacOS10dot15Available())
 
         let valet = Valet.valet(with: Identifier(nonEmpty: "PreCatalinaTest")!, accessibility: .afterFirstUnlock)
         var preCatalinaWriteQuery = valet.baseKeychainQuery
@@ -277,7 +269,17 @@ class ValetMacTests: XCTestCase
         XCTAssertEqual(try valet.object(forKey: key), object)
     }
 
+    // MARK: Private
+
     private let accessibilityValues = Accessibility.allCases
+
+    private func isMacOS10dot15Available() -> Bool {
+        if #available(macOS 10.15, *) {
+            return true
+        } else {
+            return false
+        }
+    }
 
 }
 #endif

--- a/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
@@ -35,11 +35,11 @@ class SecureEnclaveIntegrationTests: XCTestCase
     {
         super.setUp()
 
-        guard testEnvironmentIsSigned() else {
-            return
-        }
         do {
+            try XCTSkipUnless(testEnvironmentIsSigned())
             try valet.removeAllObjects()
+        } catch is XCTSkip {
+            // Nothing to do here.
         } catch {
             XCTFail("Error removing objects from Valet \(valet): \(error)")
         }
@@ -49,9 +49,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
     
     func test_secureEnclaveValetsWithEqualConfiguration_canAccessSameData() throws
     {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         try valet.setString(passcode, forKey: key)
         let equivalentValet = SecureEnclaveValet.valet(with: valet.identifier, accessControl: valet.accessControl)
@@ -61,9 +59,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
     
     func test_secureEnclaveValetsWithDifferingAccessControl_canNotAccessSameData() throws
     {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         try valet.setString(passcode, forKey: key)
         let equivalentValet = SecureEnclaveValet.valet(with: valet.identifier, accessControl: .devicePasscode)
@@ -76,11 +72,9 @@ class SecureEnclaveIntegrationTests: XCTestCase
         
     // MARK: canAccessKeychain
     
-    func test_canAccessKeychain()
+    func test_canAccessKeychain() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .valet(with: valet.identifier, accessControl: accessControl)
@@ -91,10 +85,8 @@ class SecureEnclaveIntegrationTests: XCTestCase
         }
     }
     
-    func test_canAccessKeychain_sharedAccessGroup() {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+    func test_canAccessKeychain_sharedAccessGroup() throws {
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .sharedGroupValet(with: Valet.sharedAccessGroupIdentifier, accessControl: accessControl)
@@ -107,10 +99,8 @@ class SecureEnclaveIntegrationTests: XCTestCase
 
     #if !os(macOS)
     // We can't test app groups on macOS without a paid developer account, which we don't have.
-    func test_canAccessKeychain_sharedAppGroup() {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+    func test_canAccessKeychain_sharedAppGroup() throws {
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .sharedGroupValet(with: Valet.sharedAppGroupIdentifier, accessControl: accessControl)
@@ -124,11 +114,9 @@ class SecureEnclaveIntegrationTests: XCTestCase
 
     // MARK: Migration
     
-    func test_migrateObjectsMatchingQuery_failsForBadQuery()
+    func test_migrateObjectsMatchingQuery_failsForBadQuery() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let invalidQuery = [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -141,9 +129,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclave() throws
     {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         let plainOldValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         
@@ -179,9 +165,7 @@ class SecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCalls() throws {
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         let otherValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me_To_Valet")!, accessibility: .afterFirstUnlock)
         

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -39,14 +39,12 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     {
         super.setUp()
 
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
         do {
+            try XCTSkipUnless(isTVOS11Available())
+            try XCTSkipUnless(testEnvironmentIsSigned())
             try valet().removeAllObjects()
+        } catch is XCTSkip {
+            // Nothing to do here.
         } catch {
             XCTFail("Error removing objects from Valet \(valet()): \(error)")
         }
@@ -56,12 +54,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_canAccessSameData() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         try valet().setString(passcode, forKey: key)
         let equivalentValet = SinglePromptSecureEnclaveValet.valet(with: valet().identifier, accessControl: valet().accessControl)
@@ -71,13 +65,9 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_SinglePromptSecureEnclaveValetsWithDifferingAccessControl_canNotAccessSameData() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
-        
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
+
         try valet().setString(passcode, forKey: key)
         let equivalentValet = SecureEnclaveValet.valet(with: valet().identifier, accessControl: .devicePasscode)
         XCTAssertNotEqual(valet(), equivalentValet)
@@ -91,12 +81,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_allKeys() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         XCTAssertEqual(try valet().allKeys(userPrompt: ""), Set())
         
@@ -111,12 +97,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_allKeys_doesNotReflectValetImplementationDetails() throws {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
 
         // Under the hood, Valet inserts a canary when calling `canAccessKeychain()` - this should not appear in `allKeys()`.
         _ = valet().canAccessKeychain()
@@ -125,14 +107,10 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     // MARK: canAccessKeychain
     
-    func test_canAccessKeychain()
+    func test_canAccessKeychain() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .valet(with: valet().identifier, accessControl: accessControl)
@@ -143,13 +121,9 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         }
     }
     
-    func test_canAccessKeychain_sharedAccessGroup() {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+    func test_canAccessKeychain_sharedAccessGroup() throws {
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .sharedGroupValet(with: Valet.sharedAccessGroupIdentifier, accessControl: accessControl)
@@ -162,13 +136,9 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
 
     #if !os(macOS)
     // We can't test app groups on macOS without a paid developer account, which we don't have.
-    func test_canAccessKeychain_sharedAppGroup() {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+    func test_canAccessKeychain_sharedAppGroup() throws {
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let permutations: [SecureEnclaveValet] = SecureEnclaveAccessControl.allValues().compactMap { accessControl in
             return .sharedGroupValet(with: Valet.sharedAppGroupIdentifier, accessControl: accessControl)
@@ -182,14 +152,10 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
 
     // MARK: Migration
     
-    func test_migrateObjectsMatchingQuery_failsForBadQuery()
+    func test_migrateObjectsMatchingQuery_failsForBadQuery() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let invalidQuery = [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -202,12 +168,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclave() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         let plainOldValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         
@@ -243,12 +205,8 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCalls() throws {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
-        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
-            return
-        }
+        try XCTSkipUnless(isTVOS11Available())
+        try XCTSkipUnless(testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet())
         
         let otherValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me_To_Valet")!, accessibility: .afterFirstUnlock)
         
@@ -268,6 +226,16 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         for (key, value) in keyStringPairToMigrateMap {
             XCTAssertEqual(try valet().string(forKey: key, withPrompt: ""), value)
             XCTAssertEqual(try otherValet.string(forKey: key), value)
+        }
+    }
+
+    // MARK: Private
+
+    private func isTVOS11Available() -> Bool {
+        if #available(tvOS 11.0, *) {
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -188,11 +188,9 @@ class ValetIntegrationTests: XCTestCase
         }
     }
     
-    func test_canAccessKeychain_sharedAccessGroup()
+    func test_canAccessKeychain_sharedAccessGroup() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         Valet.permutations(with: Valet.sharedAccessGroupIdentifier).forEach { permutation in
             XCTAssertTrue(permutation.canAccessKeychain(), "\(permutation) could not access keychain.")
@@ -201,11 +199,9 @@ class ValetIntegrationTests: XCTestCase
 
     #if !os(macOS)
     // We can't test app groups on macOS without a paid developer account, which we don't have.
-    func test_canAccessKeychain_sharedAppGroup()
+    func test_canAccessKeychain_sharedAppGroup() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         Valet.permutations(with: Valet.sharedAppGroupIdentifier).forEach { permutation in
             XCTAssertTrue(permutation.canAccessKeychain(), "\(permutation) could not access keychain.")
@@ -330,9 +326,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_stringForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFound() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         try vanillaValet.setString("monster", forKey: "cookie")
         XCTAssertEqual("monster", try vanillaValet.string(forKey: "cookie"))
@@ -443,9 +437,7 @@ class ValetIntegrationTests: XCTestCase
     }
     
     func test_objectForKey_withEquivalentConfigurationButDifferingFlavor_throwsItemNotFound() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         try vanillaValet.setObject(passcodeData, forKey: key)
         XCTAssertEqual(passcodeData, try vanillaValet.object(forKey: key))
@@ -652,9 +644,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_removeObjectForKey_isDistinctForDifferingClasses() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         try vanillaValet.setString(passcode, forKey: key)
         try anotherFlavor.setString(passcode, forKey: key)
@@ -671,9 +661,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_migrateObjectsMatching_failsIfQueryHasNoInputClass() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         try vanillaValet.setString(passcode, forKey: key)
 
@@ -700,9 +688,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_migrateObjectsMatching_failsIfNoItemsMatchQuery() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let queryWithNoMatches = [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -772,9 +758,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsMatchingCompactMap_successfullyMigratesTransformedKey() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -795,9 +779,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsMatchingCompactMap_successfullyMigratesTransformedValue() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -818,9 +800,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsMatchingCompactMap_returningNilDoesNotMigratePair() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -852,9 +832,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsMatchingCompactMap_throwingErrorPreventsAllMigration() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -887,9 +865,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsMatchingCompactMap_thrownErrorFromCompactMapIsRethrown() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -921,9 +897,7 @@ class ValetIntegrationTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesSingleKeyValuePairSuccessfully() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         try anotherFlavor.setString("foo", forKey: "bar")
         try vanillaValet.migrateObjects(from: anotherFlavor, removeOnCompletion: false)
@@ -933,9 +907,7 @@ class ValetIntegrationTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesMultipleKeyValuePairsSuccessfully() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let keyValuePairs = [
             "yo": "dawg",
@@ -961,9 +933,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_migrateObjectsFromValet_removesOnCompletionWhenRequested() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let keyValuePairs = [
             "yo": "dawg",
@@ -991,9 +961,7 @@ class ValetIntegrationTests: XCTestCase
 
     func test_migrateObjectsFromValet_leavesKeychainUntouchedWhenConflictsExist() throws
     {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
         
         let keyValuePairs = [
             "yo": "dawg",
@@ -1048,9 +1016,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsFromValetCompactMap_successfullyMigratesTransformedKey() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -1068,9 +1034,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsFromValetCompactMap_successfullyMigratesTransformedValue() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -1088,9 +1052,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsFromValetCompactMap_returningNilDoesNotMigratePair() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -1119,9 +1081,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsFromValetCompactMap_throwingErrorPreventsAllMigration() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()
@@ -1151,9 +1111,7 @@ class ValetIntegrationTests: XCTestCase
     }
 
     func test_migrateObjectsFromValetCompactMap_thrownErrorFromCompactMapIsRethrown() throws {
-        guard testEnvironmentIsSigned() else {
-            return
-        }
+        try XCTSkipUnless(testEnvironmentIsSigned())
 
         let migrationValet = Valet.valet(with: Identifier(nonEmpty: "Migrate_Me")!, accessibility: .afterFirstUnlock)
         try migrationValet.removeAllObjects()


### PR DESCRIPTION
@fdiaz made me aware of [Xcode's built-in ability to skip tests](https://developer.apple.com/documentation/xctest/skipping_tests). It's a more semantic way to skip a test when conditions for running the test aren't met. Previously we were using `guard`, but since there's a more semantic call we can use, let's use it!