### PR TITLE
Recommend that data should be no longer than REASONABLE_SECRET_DATA_SIZE

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Valet guarantees that reading and writing operations will succeed as long as wri
 1. Running your app in DEBUG from Xcode. Xcode sometimes does not properly sign your app, which causes a [failure to access keychain](https://github.com/square/Valet/issues/10#issuecomment-114408954) due to entitlements. If you run into this issue, just hit Run in Xcode again. This signing issue will not occur in properly signed (not DEBUG) builds.
 1. Running your app on device or in the simulator with a debugger attached may also [cause an entitlements error](https://forums.developer.apple.com/thread/4743) to be returned when reading from or writing to the keychain. To work around this issue on device, run the app without the debugger attached. After running once without the debugger attached the keychain will usually behave properly for a few runs with the debugger attached before the process needs to be repeated.
 1. Running your app or unit tests without the application-identifier entitlement. Xcode 8 introduced a requirement that all schemes must be signed with the application-identifier entitlement to access the keychain. To satisfy this requirement when running unit tests, your unit tests must be run inside of a host application.
-1. Attempting to write data more than 1mb in size. The Keychain is built to securely store small secrets – writing large blobs can crash Apple's Security daemon.
+1. Attempting to write data larger than 4kb. The Keychain is built to securely store small secrets – writing large blobs is not supported by Apple's Security daemon.
 
 ## Requirements
 

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -119,7 +119,7 @@ public final class SecureEnclaveValet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -153,7 +153,7 @@ public final class SecureEnclaveValet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -119,7 +119,7 @@ public final class SecureEnclaveValet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -153,7 +153,7 @@ public final class SecureEnclaveValet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -123,7 +123,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -157,7 +157,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -123,7 +123,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -157,7 +157,7 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -250,7 +250,7 @@ public final class Valet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -289,7 +289,7 @@ public final class Valet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserting data larger than 1mb in size may sporadically fail.
+    /// - Important: Inserted data should be smaller than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -250,7 +250,7 @@ public final class Valet: NSObject {
     ///   - object: A Data value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setObject(_ object: Data, forKey key: String) throws {
         try execute(in: lock) {
@@ -289,7 +289,7 @@ public final class Valet: NSObject {
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.
     /// - Throws: An error of type `KeychainError`.
-    /// - Important: Inserted data should be smaller than 4kb.
+    /// - Important: Inserted data should be no larger than 4kb.
     @objc
     public func setString(_ string: String, forKey key: String) throws {
         try execute(in: lock) {


### PR DESCRIPTION
See [this file](https://opensource.apple.com/source/Security/Security-59306.120.7/keychain/securityd/SecDbKeychainItemV7.m) for the constant. Follow up to #246 and #247.

Given that we have the known upper desired limit of keychain secret size (thank you @KhaosT!), I think it's reasonable for us to create a new `KeychainError` case `valueTooLarge`, and check that the entered data isn't above that limit before interacting with the `securityd`. If and when we do that, we'd want to change this `/// - Important` to a `/// - Precondition`.

Open to someone putting out a PR that does that (or I can get to it at a future date). We'd want to do this check [within `Keychain`'s `setObject(_:forKey:options:)`](https://github.com/square/Valet/blob/ec9c2a3999d2c3e2626c134b0155395ce1c58ce6/Sources/Valet/Internal/Keychain.swift#L91).

But for now, let's make sure our documentation is telling our customers the right thing per https://github.com/square/Valet/issues/246#issuecomment-691794497.