### PR TITLE
Add convenience methods for `Codable` types

### DIFF
--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -285,29 +285,29 @@ public final class Valet: NSObject {
         }
     }
 
-    /// Convenience setter for `Codable` objects. Stores them using `JSONEncoder` and the `setObject(:forKey:)` method.
+    /// Convenience setter for `Codable` objects. Utilizes the passed-in encoder to encode before storing the value in the Keychain with the `setObject(:forKey:)` method.
     ///
     /// - Parameters:
     ///   - object: A `Codable` object to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
-    ///   - jsonEncoder: The `JSONEncoder` to use for encoding the type to store. Defaults to the default initializer.
+    ///   - encoder: The `JSONEncoder` to use for encoding the type to store. Defaults to the default initializer.
     /// - Throws: An error of type `KeychainError` or an error produced while trying to encode via `JSONEncoder`.
     /// - Important: Inserted objects JSON data representation should be no larger than 4kb.
-    public func setCodable<T: Codable>(_ object: T, forKey key: String, jsonEncoder: JSONEncoder = .init()) throws {
-        let jsonData = try jsonEncoder.encode(object)
-        try setObject(jsonData, forKey: key)
+    public func setCodable<T: Codable>(_ object: T, forKey key: String, encoder: JSONEncoder = .init()) throws {
+        let encodedData = try encoder.encode(object)
+        try setObject(encodedData, forKey: key)
     }
 
-    /// Convenience getter for `Codable` objects. Reads them using `JSONDecoder` and the `object(forKey:)` method.
+    /// Convenience getter for `Codable` objects. Utilizes the passed-in decoder to decode after reading the value from the Keychain with the `object(forKey:)` method.
     ///
     /// - Parameters:
     ///   - key: A key used to retrieve the desired object from the keychain.
-    ///   - jsonDecoder: The `JSONDecoder` to use for decoding the stored data. Defaults to the default initializer.
+    ///   - decoder: The `JSONDecoder` to use for decoding the stored data. Defaults to the default initializer.
     /// - Returns: The decoded object currently stored in the keychain for the provided key.
     /// - Throws: An error of type `KeychainError` or an error produced while trying to decode via `JSONDecoder`.
-    public func codable<T: Codable>(forKey key: String, jsonDecoder: JSONDecoder = .init()) throws -> T {
-        let jsonData = try object(forKey: key)
-        return try jsonDecoder.decode(T.self, from: jsonData)
+    public func codable<T: Codable>(forKey key: String, decoder: JSONDecoder = .init()) throws -> T {
+        let encodedData = try object(forKey: key)
+        return try decoder.decode(T.self, from: encodedData)
     }
 
     /// Convenience method name for `containsObject(forKey:)` for API completeness.

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -285,6 +285,37 @@ public final class Valet: NSObject {
         }
     }
 
+    /// Convenience setter for `Codable` objects. Stores them using `JSONEncoder` and the `setObject(:forKey:)` method.
+    ///
+    /// - Parameters:
+    ///   - object: A `Codable` object to be inserted into the keychain.
+    ///   - key: A key that can be used to retrieve the `object` from the keychain.
+    /// - Throws: An error of type `KeychainError` or an error produced while trying to encode via `JSONEncoder`.
+    /// - Important: Inserted objects JSON data representation should be no larger than 4kb.
+    public func setCodable<T: Codable>(_ object: T, forKey key: String) throws {
+        let jsonData = try JSONEncoder().encode(object)
+        try setObject(jsonData, forKey: key)
+    }
+
+    /// Convenience getter for `Codable` objects. Reads them using `JSONDecoder` and the `object(forKey:)` method.
+    ///
+    /// - Parameter key: A key used to retrieve the desired object from the keychain.
+    /// - Returns: The decoded object currently stored in the keychain for the provided key.
+    /// - Throws: An error of type `KeychainError` or an error produced while trying to decode via `JSONDecoder`.
+    public func codable<T: Codable>(forKey key: String) throws -> T {
+        let jsonData = try object(forKey: key)
+        return try JSONDecoder().decode(T.self, from: jsonData)
+    }
+
+    /// Convenience method name for `containsObject(forKey:)` for API completeness.
+    ///
+    /// - Parameter key: The key to look up in the keychain.
+    /// - Returns: `true` if a value has been set for the given key, `false` otherwise.
+    /// - Throws: An error of type `KeychainError`.
+    public func containsCodable(forKey key: String) throws -> Bool {
+        try containsObject(forKey: key)
+    }
+
     /// - Parameters:
     ///   - string: A String value to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `string` from the keychain.

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -290,21 +290,24 @@ public final class Valet: NSObject {
     /// - Parameters:
     ///   - object: A `Codable` object to be inserted into the keychain.
     ///   - key: A key that can be used to retrieve the `object` from the keychain.
+    ///   - jsonEncoder: The `JSONEncoder` to use for encoding the type to store. Defaults to the default initializer.
     /// - Throws: An error of type `KeychainError` or an error produced while trying to encode via `JSONEncoder`.
     /// - Important: Inserted objects JSON data representation should be no larger than 4kb.
-    public func setCodable<T: Codable>(_ object: T, forKey key: String) throws {
-        let jsonData = try JSONEncoder().encode(object)
+    public func setCodable<T: Codable>(_ object: T, forKey key: String, jsonEncoder: JSONEncoder = .init()) throws {
+        let jsonData = try jsonEncoder.encode(object)
         try setObject(jsonData, forKey: key)
     }
 
     /// Convenience getter for `Codable` objects. Reads them using `JSONDecoder` and the `object(forKey:)` method.
     ///
-    /// - Parameter key: A key used to retrieve the desired object from the keychain.
+    /// - Parameters:
+    ///   - key: A key used to retrieve the desired object from the keychain.
+    ///   - jsonDecoder: The `JSONDecoder` to use for decoding the stored data. Defaults to the default initializer.
     /// - Returns: The decoded object currently stored in the keychain for the provided key.
     /// - Throws: An error of type `KeychainError` or an error produced while trying to decode via `JSONDecoder`.
-    public func codable<T: Codable>(forKey key: String) throws -> T {
+    public func codable<T: Codable>(forKey key: String, jsonDecoder: JSONDecoder = .init()) throws -> T {
         let jsonData = try object(forKey: key)
-        return try JSONDecoder().decode(T.self, from: jsonData)
+        return try jsonDecoder.decode(T.self, from: jsonData)
     }
 
     /// Convenience method name for `containsObject(forKey:)` for API completeness.

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -91,6 +91,11 @@ internal extension Valet {
 
 class ValetIntegrationTests: XCTestCase
 {
+    /// Workaround for an Xcode 11 bug with top-level `Codable` types (like `Array<String>`) to fix CI.
+    struct CodableArray: Codable, Equatable {
+        var stringArray: [String]
+    }
+
     static let sharedAccessGroupIdentifier = Valet.sharedAccessGroupIdentifier
     static let sharedAppGroupIdentifier = Valet.sharedAppGroupIdentifier
     var allPermutations: [Valet] {
@@ -112,7 +117,7 @@ class ValetIntegrationTests: XCTestCase
     let key = "key"
     let passcode = "topsecret"
     lazy var passcodeData: Data = { return Data(self.passcode.utf8) }()
-    var stringArray = ["Albus", "Percival", "Wulfric", "Brian", "Dumbledore"]
+    var stringArray = CodableArray(stringArray: ["Albus", "Percival", "Wulfric", "Brian", "Dumbledore"])
     
     // MARK: XCTestCase
 

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -495,7 +495,7 @@ class ValetIntegrationTests: XCTestCase
     func test_codableForKey_throwsDecoderErrorOnInvalidType() throws {
         try allPermutations.forEach { valet in
             try valet.setCodable(stringArray, forKey: key)
-            XCTAssertThrowsError(try valet.codable(forKey: self.key) as [Int]) { error in
+            XCTAssertThrowsError(try valet.codable(forKey: key) as [Int]) { error in
                 switch error {
                 case DecodingError.typeMismatch:
                     break // expected
@@ -514,6 +514,23 @@ class ValetIntegrationTests: XCTestCase
             XCTAssertThrowsError(try valet.setCodable(stringArray, forKey: "")) { error in
                 XCTAssertEqual(error as? KeychainError, .emptyKey)
             }
+        }
+    }
+
+    func test_setCodableForKey_customCoders() throws {
+        try allPermutations.forEach { valet in
+            let date = Date(timeIntervalSince1970: 1_000_000_000)
+
+            let customEncoder = JSONEncoder()
+            customEncoder.dateEncodingStrategy = .secondsSince1970
+            try valet.setCodable(date, forKey: key, jsonEncoder: customEncoder)
+
+            // default decoding strategy is `.millisecondsSince1970`, thus decoding will succeed but be different
+            XCTAssertNotEqual(date, try valet.codable(forKey: key))
+
+            let customDecoder = JSONDecoder()
+            customDecoder.dateDecodingStrategy = .secondsSince1970
+            XCTAssertEqual(date, try valet.codable(forKey: key, jsonDecoder: customDecoder))
         }
     }
     

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -522,20 +522,20 @@ class ValetIntegrationTests: XCTestCase
         }
     }
 
-    func test_setCodableForKey_customCoders() throws {
+    func test_setCodableForKey_utilizesPassedInCoder() throws {
         try allPermutations.forEach { valet in
             let date = Date(timeIntervalSince1970: 1_000_000_000)
 
             let customEncoder = JSONEncoder()
             customEncoder.dateEncodingStrategy = .secondsSince1970
-            try valet.setCodable(date, forKey: key, jsonEncoder: customEncoder)
+            try valet.setCodable(date, forKey: key, encoder: customEncoder)
 
             // default decoding strategy is `.millisecondsSince1970`, thus decoding will succeed but be different
             XCTAssertNotEqual(date, try valet.codable(forKey: key))
 
             let customDecoder = JSONDecoder()
             customDecoder.dateDecodingStrategy = .secondsSince1970
-            XCTAssertEqual(date, try valet.codable(forKey: key, jsonDecoder: customDecoder))
+            XCTAssertEqual(date, try valet.codable(forKey: key, decoder: customDecoder))
         }
     }
     

--- a/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/ValetIntegrationTests.swift
@@ -112,6 +112,7 @@ class ValetIntegrationTests: XCTestCase
     let key = "key"
     let passcode = "topsecret"
     lazy var passcodeData: Data = { return Data(self.passcode.utf8) }()
+    var stringArray = ["Albus", "Percival", "Wulfric", "Brian", "Dumbledore"]
     
     // MARK: XCTestCase
 
@@ -451,7 +452,7 @@ class ValetIntegrationTests: XCTestCase
         }
     }
     
-    // MARK: set(object:forKey:)
+    // MARK: setObject(:forKey:)
 
     func test_setObjectForKey_successfullyUpdatesExistingKey() throws {
         try allPermutations.forEach { valet in
@@ -478,6 +479,40 @@ class ValetIntegrationTests: XCTestCase
             XCTAssertTrue(emptyData.isEmpty)
             XCTAssertThrowsError(try valet.setObject(emptyData, forKey: key)) { error in
                 XCTAssertEqual(error as? KeychainError, .emptyValue)
+            }
+        }
+    }
+
+    // MARK: codable(forKey:)
+
+    func test_codableForKey_succeedsForValidKey() throws {
+        try allPermutations.forEach { valet in
+            try valet.setCodable(stringArray, forKey: key)
+            XCTAssertEqual(stringArray, try valet.codable(forKey: key))
+        }
+    }
+
+    func test_codableForKey_throwsDecoderErrorOnInvalidType() throws {
+        try allPermutations.forEach { valet in
+            try valet.setCodable(stringArray, forKey: key)
+            XCTAssertThrowsError(try valet.codable(forKey: self.key) as [Int]) { error in
+                switch error {
+                case DecodingError.typeMismatch:
+                    break // expected
+
+                default:
+                    XCTFail("Unexpected error: \(error)")
+                }
+            }
+        }
+    }
+
+    // MARK: setCodable(:forKey:)
+
+    func test_setCodableForKey_throwsEmptyKeyOnInvalidKey() throws {
+        try allPermutations.forEach { valet in
+            XCTAssertThrowsError(try valet.setCodable(stringArray, forKey: "")) { error in
+                XCTAssertEqual(error as? KeychainError, .emptyKey)
             }
         }
     }

--- a/Valet.xcodeproj/project.pbxproj
+++ b/Valet.xcodeproj/project.pbxproj
@@ -836,7 +836,9 @@
 				EA1E1F841A8C46080067C991 /* Products */,
 				168909331F7199B50057F636 /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		EA1E1F841A8C46080067C991 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This fixes #254.

I also added some basic tests, but not as detailed because these new methods just call other already well tested methods. I didn't see the need to re-test their logic here as that would only create redundancy. But I added tests for the rethrowing behavior of decoding errors so the library doesn't take any responsibility for error handling there.

Possible changelog entry (couldn't find a `CHANGELOG.md` file):
- Adds new `codable(forKey:jsonDecoder:)`, `setCodable(:forKey:jsonEncoder:)` and `containsCodable(forKey:)` convenience methods for storing `Codable` types. Defaults to `JSONEncoder()`/`JSONDecoder()` for convenience.

Please note that I have also made **2 minor adjustments** to improve the code elsewhere (which I can remove if requested):
1. I renamed the comment in the tests from `// MARK: set(object:forKey:)` to `// MARK: setObject(:forKey:)` to use the correct method name.
2. Added explicit project preference settings for `tabWidth` and `indentWidth` so contributors using a different global setting don't mess with indentation accidentally.