### PR TITLE
Make afterFirstUnlock documentation more clear

### DIFF
--- a/Sources/Valet/Accessibility.swift
+++ b/Sources/Valet/Accessibility.swift
@@ -21,14 +21,14 @@ import Foundation
 public enum Accessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
-    /// Valet data is accessible except between device restart and first unlock. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
+    /// Valet data cannot be accessed after a restart until the device has been unlocked once; data is accessible until the device is next rebooted. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case afterFirstUnlock = 2
 
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for items that only need to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device. No items can be stored in this class on devices without a passcode. Disabling the device passcode will cause all items in this class to be deleted.
     case whenPasscodeSetThisDeviceOnly = 4
     /// Valet data can only be accessed while the device is unlocked. This is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
     case whenUnlockedThisDeviceOnly = 5
-    /// Valet data is accessible except between device restart and first unlock. This is recommended for items that need to be accessible by background applications. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
+    /// Valet data cannot be accessed after a restart until the device has been unlocked once; data is accessible until the device is next rebooted. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case afterFirstUnlockThisDeviceOnly = 6
 
     // MARK: CustomStringConvertible

--- a/Sources/Valet/Accessibility.swift
+++ b/Sources/Valet/Accessibility.swift
@@ -21,14 +21,14 @@ import Foundation
 public enum Accessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
-    /// Valet data can only be accessed once the device has been unlocked after a restart. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
+    /// Valet data is accessible except between device restart and first unlock. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case afterFirstUnlock = 2
 
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for items that only need to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device. No items can be stored in this class on devices without a passcode. Disabling the device passcode will cause all items in this class to be deleted.
     case whenPasscodeSetThisDeviceOnly = 4
     /// Valet data can only be accessed while the device is unlocked. This is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
     case whenUnlockedThisDeviceOnly = 5
-    /// Valet data can only be accessed once the device has been unlocked after a restart. This is recommended for items that need to be accessible by background applications. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
+    /// Valet data is accessible except between device restart and first unlock. This is recommended for items that need to be accessible by background applications. Valet data with this attribute will never migrate to a new device, so these items will be missing after a backup is restored to a new device.
     case afterFirstUnlockThisDeviceOnly = 6
 
     // MARK: CustomStringConvertible

--- a/Sources/Valet/CloudAccessibility.swift
+++ b/Sources/Valet/CloudAccessibility.swift
@@ -21,7 +21,7 @@ import Foundation
 public enum CloudAccessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
-    /// Valet data can only be accessed once the device has been unlocked after a restart. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
+    /// Valet data is accessible except between device restart and first unlock. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case afterFirstUnlock = 2
 
     // MARK: CustomStringConvertible

--- a/Sources/Valet/CloudAccessibility.swift
+++ b/Sources/Valet/CloudAccessibility.swift
@@ -21,7 +21,7 @@ import Foundation
 public enum CloudAccessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
-    /// Valet data is accessible except between device restart and first unlock. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
+    /// Valet data cannot be accessed after a restart until the device has been unlocked once; data is accessible until the device is next rebooted. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case afterFirstUnlock = 2
 
     // MARK: CustomStringConvertible


### PR DESCRIPTION
Attempts to resolve #257. The conditions that lead to data under `afterFirstUnlock` being inaccessible is more clear than the conditions that lead to the data being accessible, so I inverted the sentence a bit. I liked the consistency brought by always stating when the data was accessible, but I was having trouble finding a way to word that clearly given the feedback we received in #257. Open to feedback or alternative wording suggestions!

Note that I didn't change the documentation in `VALLegacyValet`, since that file is no longer public and utilized only by our test suite.

cc @sergstav