### PR TITLE
Remove build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Valet
 
-[![CI Status](https://travis-ci.org/square/Valet.svg?branch=master)](https://travis-ci.org/square/Valet)
 [![Carthage Compatibility](https://img.shields.io/badge/carthage-✓-e2c245.svg)](https://github.com/Carthage/Carthage/)
 [![Version](https://img.shields.io/cocoapods/v/Valet.svg)](https://cocoapods.org/pods/Valet)
 [![License](https://img.shields.io/cocoapods/l/Valet.svg)](https://cocoapods.org/pods/Valet)


### PR DESCRIPTION
We're no longer using Travis CI so this badge will eventually get out of date. Let's just remove it. I'm not convinced it had much value to begin with.