### PR TITLE
Remove SinglePromptSecureEnclaveValet from tvOS targets

### DIFF
--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+#if !os(tvOS)
 #if canImport(LocalAuthentication)
 
 import LocalAuthentication
@@ -21,7 +22,6 @@ import Foundation
 
 
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. The first access of these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SinglePromptSecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
-@available(tvOS 11.0, *)
 @objc(VALSinglePromptSecureEnclaveValet)
 public final class SinglePromptSecureEnclaveValet: NSObject {
     
@@ -277,7 +277,6 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
 // MARK: - Objective-C Compatibility
 
 
-@available(tvOS 11.0, *)
 extension SinglePromptSecureEnclaveValet {
     
     // MARK: Public Class Methods
@@ -337,4 +336,5 @@ extension SinglePromptSecureEnclaveValet {
 
 }
 
+#endif
 #endif

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -14,8 +14,8 @@
 //  limitations under the License.
 //
 
-#if !os(tvOS)
-#if canImport(LocalAuthentication)
+// Xcode 13 and prior incorrectly say that LocalAuthentication is available on tvOS, so we have to check both as long as Xcode 13 and prior are supported.
+#if !os(tvOS) && canImport(LocalAuthentication)
 
 import LocalAuthentication
 import Foundation
@@ -336,5 +336,4 @@ extension SinglePromptSecureEnclaveValet {
 
 }
 
-#endif
 #endif

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -18,8 +18,8 @@ import Foundation
 @testable import Valet
 import XCTest
 
-#if !os(tvOS)
-#if canImport(LocalAuthentication)
+// Xcode 13 and prior incorrectly say that LocalAuthentication is available on tvOS, so we have to check both as long as Xcode 13 and prior are supported.
+#if !os(tvOS) && canImport(LocalAuthentication)
 
 class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
 {
@@ -235,5 +235,4 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
 }
 
-#endif
 #endif

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -18,13 +18,13 @@ import Foundation
 @testable import Valet
 import XCTest
 
+#if !os(tvOS)
 #if canImport(LocalAuthentication)
 
 class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
 {
     static let identifier = Identifier(nonEmpty: "valet_testing")!
 
-    @available(tvOS 11.0, *)
     func valet() -> SinglePromptSecureEnclaveValet {
         .valet(with: SinglePromptSecureEnclaveTests.identifier, accessControl: .userPresence)
     }
@@ -35,9 +35,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     {
         super.setUp()
 
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -52,9 +49,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         
     func test_SinglePromptSecureEnclaveValetsWithEqualConfiguration_canAccessSameData() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -67,9 +61,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_SinglePromptSecureEnclaveValetsWithDifferingAccessControl_canNotAccessSameData() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -87,9 +78,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_allKeys() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -107,9 +95,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_allKeys_doesNotReflectValetImplementationDetails() throws {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -123,9 +108,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_canAccessKeychain()
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -140,9 +122,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_canAccessKeychain_sharedAccessGroup() {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -159,9 +138,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     #if !os(macOS)
     // We can't test app groups on macOS without a paid developer account, which we don't have.
     func test_canAccessKeychain_sharedAppGroup() {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -180,9 +156,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_migrateObjectsMatchingQuery_failsForBadQuery()
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() else {
             return
         }
@@ -198,9 +171,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     
     func test_migrateObjectsFromValet_migratesSuccessfullyToSecureEnclave() throws
     {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -239,9 +209,6 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
     
     func test_migrateObjectsFromValet_migratesSuccessfullyAfterCanAccessKeychainCalls() throws {
-        guard #available(tvOS 11.0, *) else {
-            return
-        }
         guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
             return
         }
@@ -268,4 +235,5 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
     }
 }
 
+#endif
 #endif

--- a/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
@@ -16,9 +16,7 @@
 #import <Valet/Valet.h>
 #import <XCTest/XCTest.h>
 
-#if TARGET_OS_TV
-
-#else
+#if !TARGET_OS_TV
 
 @interface VALSinglePromptSecureEnclaveValetTests : XCTestCase
 @end

--- a/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
+++ b/Tests/ValetObjectiveCBridgeTests/VALSinglePromptSecureEnclaveValetTests.m
@@ -16,6 +16,10 @@
 #import <Valet/Valet.h>
 #import <XCTest/XCTest.h>
 
+#if TARGET_OS_TV
+
+#else
+
 @interface VALSinglePromptSecureEnclaveValetTests : XCTestCase
 @end
 
@@ -66,134 +70,106 @@
 
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlUserPresence;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlUserPresence];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlUserPresence];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricAny;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_valetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricCurrentSet;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:self.identifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_valetWithIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertNil(valet);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet valetWithIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertNil(valet);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlUserPresence;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricAny;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricCurrentSet;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:self.sharedAccessGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAccessGroupValetWithIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertNil(valet);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithAppIDPrefix:self.appIDPrefix sharedGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertNil(valet);
 }
 
 - (void)test_sharedAppGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlDevicePasscode;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlDevicePasscode];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlDevicePasscode);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAppGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlUserPresence;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlUserPresence];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlUserPresence);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAppGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricAny;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricAny];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricAny);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAppGroupValetWithIdentifier_accessControl_returnsCorrectValet_VALSecureEnclaveAccessControlBiometricCurrentSet;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
-        XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:self.sharedAppGroupIdentifier accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertEqual(valet.accessControl, VALSecureEnclaveAccessControlBiometricCurrentSet);
+    XCTAssertEqual([valet class], [VALSinglePromptSecureEnclaveValet class]);
 }
 
 - (void)test_sharedAppGroupValetWithIdentifier_accessibility_returnsNilWhenIdentifierIsEmpty;
 {
-    if (@available(tvOS 11.0, *)) {
-        VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
-        XCTAssertNil(valet);
-    }
+    VALSinglePromptSecureEnclaveValet *const valet = [VALSinglePromptSecureEnclaveValet sharedGroupValetWithGroupPrefix:self.groupPrefix sharedGroupIdentifier:@"" accessControl:VALSecureEnclaveAccessControlBiometricCurrentSet];
+    XCTAssertNil(valet);
 }
 
 @end
+
+#endif

--- a/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+#if !os(tvOS)
 #if canImport(LocalAuthentication)
 
 import Foundation
@@ -21,7 +22,6 @@ import Foundation
 import XCTest
 
 
-@available(tvOS 11.0, *)
 class SinglePromptSecureEnclaveTests: XCTestCase
 {
     static let identifier = Identifier(nonEmpty: "valet_testing")!
@@ -57,4 +57,5 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
 }
 
+#endif
 #endif

--- a/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
@@ -14,8 +14,8 @@
 //  limitations under the License.
 //
 
-#if !os(tvOS)
-#if canImport(LocalAuthentication)
+// Xcode 13 and prior incorrectly say that LocalAuthentication is available on tvOS, so we have to check both as long as Xcode 13 and prior are supported.
+#if !os(tvOS) && canImport(LocalAuthentication)
 
 import Foundation
 @testable import Valet
@@ -57,5 +57,4 @@ class SinglePromptSecureEnclaveTests: XCTestCase
     }
 }
 
-#endif
 #endif


### PR DESCRIPTION
LAContext is not available in tvOS, but for some reason it was compiling in older Xcode versions.