### PR TITLE
Add support for multiple Valets within the same access group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.11.0'
-end
+source "https://rubygems.org"
+
+gem 'cocoapods', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,4 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.6)
@@ -94,7 +91,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.11.0)!
+  cocoapods (~> 1.11.0)
 
 BUNDLED WITH
    2.3.7

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ VALValet *const mySharedValet = [VALValet sharedGroupValetWithGroupPrefix:@"grou
 
 This instance can be used to store and retrieve data securely across any app written by the same developer that has `group.Druidia` set as a value for the `com.apple.security.application-groups` key in the app’s `Entitlements`. This Valet is accessible when the device is unlocked. Note that `myValet` and `mySharedValet` cannot read or modify one another’s values because the two Valets were created with different initializers. All Valet types can share secrets across applications written by the same developer by using the `sharedGroupValet` initializer. Note that on macOS, the `groupPrefix` [must be the App ID prefix](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups#discussion).
 
+As with Valets, shared iCloud Valets can be created with an additional identifier, allowing multiple independently sandboxed keychains to exist within the same shared group.
+
 ### Sharing Secrets Across Devices with iCloud
 
 ```swift
@@ -180,6 +182,8 @@ VALValet *const myCloudValet = [VALValet iCloudValetWithIdentifier:@"Druidia" ac
 ```
 
 This instance can be used to store and retrieve data that can be retrieved by this app on other devices logged into the same iCloud account with iCloud Keychain enabled. If iCloud Keychain is not enabled on this device, secrets can still be read and written, but will not sync to other devices. Note that  `myCloudValet` can not read or modify values in either `myValet` or `mySharedValet` because `myCloudValet` was created a different initializer.
+
+Shared iCloud Valets can be created with an additional identifier, allowing multiple independently sandboxed keychains to exist within the same iCloud shared group.
 
 ### Protecting Secrets with Face ID, Touch ID, or device Passcode
 

--- a/Sources/Valet/SecureEnclave.swift
+++ b/Sources/Valet/SecureEnclave.swift
@@ -38,8 +38,8 @@ public final class SecureEnclave {
         case let .sharedGroupOverride(identifier, _):
             noPromptValet = .sharedGroupValet(withExplicitlySet: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         #endif
-        case let .sharedGroup(identifier, _):
-            noPromptValet = .sharedGroupValet(with: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
+        case let .sharedGroup(groupIdentifier, identifier, _):
+            noPromptValet = .sharedGroupValet(with: groupIdentifier, identifier: identifier, accessibility: .whenPasscodeSetThisDeviceOnly)
         }
         
         return noPromptValet.canAccessKeychain()

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -43,13 +43,13 @@ public final class SecureEnclaveValet: NSObject {
     ///   - identifier: A non-empty string that must correspond with the value for keychain-access-groups in your Entitlements file.
     ///   - accessControl: The desired access control for the SecureEnclaveValet.
     /// - Returns: A SecureEnclaveValet that reads/writes keychain elements that can be shared across applications written by the same development team.
-    public class func sharedGroupValet(with identifier: SharedGroupIdentifier, accessControl: SecureEnclaveAccessControl) -> SecureEnclaveValet {
-        let key = Service.sharedGroup(identifier, .secureEnclave(accessControl)).description as NSString
+    public class func sharedGroupValet(with groupIdentifier: SharedGroupIdentifier, identifier: Identifier? = nil, accessControl: SecureEnclaveAccessControl) -> SecureEnclaveValet {
+        let key = Service.sharedGroup(groupIdentifier, identifier, .secureEnclave(accessControl)).description as NSString
         if let existingValet = identifierToValetMap.object(forKey: key) {
             return existingValet
             
         } else {
-            let valet = SecureEnclaveValet(sharedAccess: identifier, accessControl: accessControl)
+            let valet = SecureEnclaveValet(sharedAccess: groupIdentifier, identifier: identifier, accessControl: accessControl)
             identifierToValetMap.setObject(valet, forKey: key)
             return valet
         }
@@ -80,11 +80,12 @@ public final class SecureEnclaveValet: NSObject {
             accessControl: accessControl)
     }
     
-    private convenience init(sharedAccess groupIdentifier: SharedGroupIdentifier, accessControl: SecureEnclaveAccessControl) {
+    private convenience init(sharedAccess groupIdentifier: SharedGroupIdentifier, identifier: Identifier? = nil, accessControl: SecureEnclaveAccessControl) {
         self.init(
-            identifier: groupIdentifier.asIdentifier,
-            service: .sharedGroup(groupIdentifier, .secureEnclave(accessControl)),
-            accessControl: accessControl)
+            identifier: identifier ?? groupIdentifier.asIdentifier,
+            service: .sharedGroup(groupIdentifier, identifier, .secureEnclave(accessControl)),
+            accessControl: accessControl
+        )
     }
 
     private init(identifier: Identifier, service: Service, accessControl: SecureEnclaveAccessControl) {

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -47,13 +47,13 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
     ///   - identifier: A non-empty identifier that must correspond with the value for keychain-access-groups in your Entitlements file.
     ///   - accessControl: The desired access control for the SinglePromptSecureEnclaveValet.
     /// - Returns: A SinglePromptSecureEnclaveValet that reads/writes keychain elements that can be shared across applications written by the same development team.
-    public class func sharedGroupValet(with identifier: SharedGroupIdentifier, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet {
-        let key = Service.sharedGroup(identifier, .singlePromptSecureEnclave(accessControl)).description as NSString
+    public class func sharedGroupValet(with groupIdentifier: SharedGroupIdentifier, identifier: Identifier? = nil, accessControl: SecureEnclaveAccessControl) -> SinglePromptSecureEnclaveValet {
+        let key = Service.sharedGroup(groupIdentifier, identifier, .singlePromptSecureEnclave(accessControl)).description as NSString
         if let existingValet = identifierToValetMap.object(forKey: key) {
             return existingValet
             
         } else {
-            let valet = SinglePromptSecureEnclaveValet(sharedAccess: identifier, accessControl: accessControl)
+            let valet = SinglePromptSecureEnclaveValet(sharedAccess: groupIdentifier, identifier: identifier, accessControl: accessControl)
             identifierToValetMap.setObject(valet, forKey: key)
             return valet
         }
@@ -84,10 +84,10 @@ public final class SinglePromptSecureEnclaveValet: NSObject {
             accessControl: accessControl)
     }
     
-    private convenience init(sharedAccess groupIdentifier: SharedGroupIdentifier, accessControl: SecureEnclaveAccessControl) {
+    private convenience init(sharedAccess groupIdentifier: SharedGroupIdentifier, identifier: Identifier? = nil, accessControl: SecureEnclaveAccessControl) {
         self.init(
-            identifier: groupIdentifier.asIdentifier,
-            service: .sharedGroup(groupIdentifier, .singlePromptSecureEnclave(accessControl)),
+            identifier: identifier ?? groupIdentifier.asIdentifier,
+            service: .sharedGroup(groupIdentifier, identifier, .singlePromptSecureEnclave(accessControl)),
             accessControl: accessControl)
     }
 

--- a/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
+++ b/Tests/ValetIntegrationTests/BackwardsCompatibilityTests/ValetBackwardsCompatibilityTests.swift
@@ -27,7 +27,7 @@ internal extension Valet {
 
     var legacyIdentifier: String {
         switch service {
-        case let .sharedGroup(sharedAccessGroupIdentifier, _):
+        case let .sharedGroup(sharedAccessGroupIdentifier, _, _):
             return sharedAccessGroupIdentifier.groupIdentifier
         case let .standard(identifier, _):
             return identifier.description

--- a/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SecureEnclaveIntegrationTests.swift
@@ -69,6 +69,24 @@ class SecureEnclaveIntegrationTests: XCTestCase
             XCTAssertEqual(error as? KeychainError, .itemNotFound)
         }
     }
+
+    func test_secureEnclaveSharedGroupValetsWithDifferingIdentifiers_canNotAccessSameData() throws
+    {
+        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
+            return
+        }
+
+        let valet1 = SecureEnclaveValet.sharedGroupValet(with: Valet.sharedAccessGroupIdentifier, identifier: Identifier(nonEmpty: "valet1"), accessControl: .devicePasscode)
+        let valet2 = SecureEnclaveValet.sharedGroupValet(with: Valet.sharedAccessGroupIdentifier, identifier: Identifier(nonEmpty: "valet2"), accessControl: .devicePasscode)
+
+        try valet1.setString(passcode, forKey: key)
+
+        XCTAssertNotEqual(valet1, valet2)
+        XCTAssertEqual(passcode, try valet1.string(forKey: key, withPrompt: ""))
+        XCTAssertThrowsError(try valet2.string(forKey: key, withPrompt: "")) { error in
+            XCTAssertEqual(error as? KeychainError, .itemNotFound)
+        }
+    }
         
     // MARK: canAccessKeychain
     

--- a/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
+++ b/Tests/ValetIntegrationTests/SinglePromptSecureEnclaveIntegrationTests.swift
@@ -74,6 +74,24 @@ class SinglePromptSecureEnclaveIntegrationTests: XCTestCase
         }
     }
 
+    func test_SinglePromptSecureEnclaveValetsWithDifferingIdentifiers_canNotAccessSameData() throws
+    {
+        guard testEnvironmentIsSigned() && testEnvironmentSupportsWhenPasscodeSet() else {
+            return
+        }
+
+        let valet1 = SinglePromptSecureEnclaveValet.sharedGroupValet(with: Valet.sharedAppGroupIdentifier, identifier: Identifier(nonEmpty: "valet1"), accessControl: .devicePasscode)
+        let valet2 = SinglePromptSecureEnclaveValet.sharedGroupValet(with: Valet.sharedAppGroupIdentifier, identifier: Identifier(nonEmpty: "valet2"), accessControl: .devicePasscode)
+
+        try valet1.setString(passcode, forKey: key)
+
+        XCTAssertNotEqual(valet1, valet2)
+        XCTAssertEqual(passcode, try valet1.string(forKey: key, withPrompt: ""))
+        XCTAssertThrowsError(try valet2.string(forKey: key, withPrompt: "")) { error in
+            XCTAssertEqual(error as? KeychainError, .itemNotFound)
+        }
+    }
+
     // MARK: allKeys
     
     func test_allKeys() throws

--- a/Tests/ValetTests/SecureEnclaveTests.swift
+++ b/Tests/ValetTests/SecureEnclaveTests.swift
@@ -41,7 +41,17 @@ class SecureEnclaveTests: XCTestCase
 
         SecureEnclaveAccessControl.allValues().forEach { accessControl in
             let backingService = SecureEnclaveValet.sharedGroupValet(with: identifier, accessControl: accessControl).service
-            XCTAssertEqual(backingService, Service.sharedGroup(identifier, .secureEnclave(accessControl)))
+            XCTAssertEqual(backingService, Service.sharedGroup(identifier, nil, .secureEnclave(accessControl)))
+        }
+    }
+
+    func test_init_createsCorrectBackingService_sharedAccess_withIdentifier() {
+        let groupIdentifier = Valet.sharedAccessGroupIdentifier
+        let identifier = Identifier(nonEmpty: "id")
+
+        SecureEnclaveAccessControl.allValues().forEach { accessControl in
+            let backingService = SecureEnclaveValet.sharedGroupValet(with: groupIdentifier, identifier: identifier, accessControl: accessControl).service
+            XCTAssertEqual(backingService, Service.sharedGroup(groupIdentifier, identifier, .secureEnclave(accessControl)))
         }
     }
 

--- a/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
+++ b/Tests/ValetTests/SinglePromptSecureEnclaveTests.swift
@@ -43,7 +43,7 @@ class SinglePromptSecureEnclaveTests: XCTestCase
 
         SecureEnclaveAccessControl.allValues().forEach { accessControl in
             let backingService = SinglePromptSecureEnclaveValet.sharedGroupValet(with: identifier, accessControl: accessControl).service
-            XCTAssertEqual(backingService, Service.sharedGroup(identifier, .singlePromptSecureEnclave(accessControl)))
+            XCTAssertEqual(backingService, Service.sharedGroup(identifier, nil, .singlePromptSecureEnclave(accessControl)))
         }
     }
 

--- a/Tests/ValetTests/ValetTests.swift
+++ b/Tests/ValetTests/ValetTests.swift
@@ -41,7 +41,17 @@ class ValetTests: XCTestCase
 
         Accessibility.allCases.forEach { accessibility in
             let backingService = Valet.sharedGroupValet(with: identifier, accessibility: accessibility).service
-            XCTAssertEqual(backingService, Service.sharedGroup(identifier, .valet(accessibility)))
+            XCTAssertEqual(backingService, Service.sharedGroup(identifier, nil, .valet(accessibility)))
+        }
+    }
+
+    func test_init_createsCorrectBackingService_sharedAccess_withIdentifier() {
+        let groupIdentifier = Valet.sharedAccessGroupIdentifier
+        let identifier = Identifier(nonEmpty: "UniquenessIdentifier")
+
+        Accessibility.allCases.forEach { accessibility in
+            let backingService = Valet.sharedGroupValet(with: groupIdentifier, identifier: identifier, accessibility: accessibility).service
+            XCTAssertEqual(backingService, Service.sharedGroup(groupIdentifier, identifier, .valet(accessibility)))
         }
     }
 
@@ -59,7 +69,7 @@ class ValetTests: XCTestCase
 
         CloudAccessibility.allCases.forEach { accessibility in
             let backingService = Valet.iCloudSharedGroupValet(with: identifier, accessibility: accessibility).service
-            XCTAssertEqual(backingService, Service.sharedGroup(identifier, .iCloud(accessibility)))
+            XCTAssertEqual(backingService, Service.sharedGroup(identifier, nil, .iCloud(accessibility)))
         }
     }
 

--- a/Valet iOS Test Host App/Valet iOS Test Host App.entitlements
+++ b/Valet iOS Test Host App/Valet iOS Test Host App.entitlements
@@ -9,6 +9,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.squareup.Valet-iOS-Test-Host-App</string>
+		<string>$(AppIdentifierPrefix)com.squareup.Valet-iOS-Test-Host-App2</string>
 	</array>
 </dict>
 </plist>

--- a/Valet macOS Test Host App/Valet_macOS_Test_Host_App.entitlements
+++ b/Valet macOS Test Host App/Valet_macOS_Test_Host_App.entitlements
@@ -13,6 +13,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.squareup.Valet-macOS-Test-Host-App</string>
+		<string>$(AppIdentifierPrefix)com.squareup.Valet-macOS-Test-Host-App2</string>
 	</array>
 </dict>
 </plist>

--- a/Valet tvOS Test Host App/Valet tvOS Test Host App.entitlements
+++ b/Valet tvOS Test Host App/Valet tvOS Test Host App.entitlements
@@ -9,6 +9,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.squareup.Valet-tvOS-Test-Host-App</string>
+		<string>$(AppIdentifierPrefix)com.squareup.Valet-tvOS-Test-Host-App2</string>
 	</array>
 </dict>
 </plist>

--- a/Valet watchOS Test Host App Extension/Valet watchOS Test Host App Extension.entitlements
+++ b/Valet watchOS Test Host App Extension/Valet watchOS Test Host App Extension.entitlements
@@ -9,6 +9,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension</string>
+		<string>$(AppIdentifierPrefix)com.squareup.ValetTouchIDTestApp.watchkitapp.watchkitextension2</string>
 	</array>
 </dict>
 </plist>

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '4.1.3'
+  s.version  = '4.2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data on iOS, tvOS, watchOS, or macOS without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'

--- a/Valet.xcodeproj/xcshareddata/xcschemes/Valet watchOS Test Host App Extension.xcscheme
+++ b/Valet.xcodeproj/xcshareddata/xcschemes/Valet watchOS Test Host App Extension.xcscheme
@@ -77,10 +77,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Valet watchOS Test Host App Extension">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "16DF6AFE204B496800F8E0A4"
@@ -88,7 +86,7 @@
             BlueprintName = "Valet watchOS Test Host App Extension"
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -96,10 +94,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/Valet watchOS Test Host App Extension">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "16DF6AFE204B496800F8E0A4"
@@ -107,16 +103,7 @@
             BlueprintName = "Valet watchOS Test Host App Extension"
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "16DF6AFE204B496800F8E0A4"
-            BuildableName = "Valet watchOS Test Host App Extension.appex"
-            BlueprintName = "Valet watchOS Test Host App Extension"
-            ReferencedContainer = "container:Valet.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Valet.xcodeproj/xcshareddata/xcschemes/Valet watchOS Test Host App.xcscheme
+++ b/Valet.xcodeproj/xcshareddata/xcschemes/Valet watchOS Test Host App.xcscheme
@@ -63,10 +63,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ValetTouchIDTest">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "16DF6AF2204B496800F8E0A4"
@@ -74,7 +72,7 @@
             BlueprintName = "Valet watchOS Test Host App"
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,10 +80,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/ValetTouchIDTest">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "16DF6AF2204B496800F8E0A4"
@@ -93,16 +89,7 @@
             BlueprintName = "Valet watchOS Test Host App"
             ReferencedContainer = "container:Valet.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "16DF6AF2204B496800F8E0A4"
-            BuildableName = "Valet watchOS Test Host App.app"
-            BlueprintName = "Valet watchOS Test Host App"
-            ReferencedContainer = "container:Valet.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Previously, the shared access group identifier was used for both the access group itself, as well as the uniqueness identifier for the given Valet. This adds an optional additional `identifier` parameter that can be specified when creating a shared access group Valet. The identifier adds an additional element of uniqueness, so two Valets with the same shared access group can exist, and their data will not overlap, so long as they have different identifiers.
    
The default for this value is `nil`, which keeps the existing behavior for full backward compatibility.