### PR TITLE
Add iOS 13 back to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
       matrix:
         platforms: [
           'iOS_14,tvOS_14,watchOS_7',
-           # TODO: add iOS_13 back once https://github.com/actions/runner-images/issues/7687 is resolved
-          'tvOS_13,watchOS_6',
+          'iOS_13,tvOS_13,watchOS_6',
         ]
       fail-fast: false
     timeout-minutes: 30


### PR DESCRIPTION
As title. Per https://github.com/actions/runner-images/issues/7687#issuecomment-1620396057 it's time to add this back.