### PR TITLE
Make core types Sendable and @unchecked Sendable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_14.3.app/Contents/Developer
       - name: Lint Podspec
-        run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.0
+        run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.4
   carthage:
     name: Carthage
     runs-on: macOS-13
@@ -118,7 +118,6 @@ jobs:
           'iOS_14,tvOS_14,watchOS_7',
           'iOS_13,tvOS_13,watchOS_6',
           'macOS_11',
-          'macOS_10_15',
         ]
       fail-fast: false
     steps:
@@ -135,9 +134,6 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_12.5.1.app/Contents/Developer
         if: ${{ matrix.platforms == 'macOS_11' }}
-      - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
-        if: ${{ matrix.platforms == 'macOS_10_15' }}
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
       - name: Build Framework

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Valet guarantees that reading and writing operations will succeed as long as wri
 
 ## Requirements
 
-* Xcode 11.0 or later. Xcode 10 and Xcode 9 require [Valet version 3.2.8](https://github.com/square/Valet/releases/tag/3.2.8). Earlier versions of Xcode require [Valet version 2.4.2](https://github.com/square/Valet/releases/tag/2.4.2).
+* Xcode 12.5 or later.
 * iOS 9 or later.
 * tvOS 9 or later.
 * watchOS 2 or later.

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -31,7 +31,6 @@ enum Platform: String, CustomStringConvertible {
     case tvOS_15
     case tvOS_16
     case tvOS_17
-    case macOS_10_15
     case macOS_11
     case macOS_12
     case macOS_13
@@ -66,8 +65,7 @@ enum Platform: String, CustomStringConvertible {
         case .tvOS_17:
             return "platform=tvOS Simulator,OS=17.0,name=Apple TV"
 
-        case .macOS_10_15,
-             .macOS_11,
+        case .macOS_11,
              .macOS_12,
              .macOS_13,
              .macOS_14:
@@ -102,8 +100,6 @@ enum Platform: String, CustomStringConvertible {
              .tvOS_17:
             return "appletvsimulator"
 
-        case .macOS_10_15:
-            return "macosx10.15"
         case .macOS_11:
             return "macosx11.1"
         case .macOS_12:
@@ -134,7 +130,6 @@ enum Platform: String, CustomStringConvertible {
              .tvOS_15,
              .tvOS_16,
              .tvOS_17,
-             .macOS_10_15,
              .macOS_11,
              .macOS_12,
              .macOS_13,
@@ -182,8 +177,7 @@ enum Platform: String, CustomStringConvertible {
              .tvOS_17:
             return "Valet tvOS"
 
-        case .macOS_10_15,
-             .macOS_11,
+        case .macOS_11,
              .macOS_12,
              .macOS_13,
              .macOS_14:

--- a/Sources/Valet/Accessibility.swift
+++ b/Sources/Valet/Accessibility.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 @objc(VALAccessibility)
-public enum Accessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
+public enum Accessibility: Int, CaseIterable, CustomStringConvertible, Equatable, Sendable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
     /// Valet data cannot be accessed after a restart until the device has been unlocked once; data is accessible until the device is next rebooted. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.

--- a/Sources/Valet/CloudAccessibility.swift
+++ b/Sources/Valet/CloudAccessibility.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 @objc(VALCloudAccessibility)
-public enum CloudAccessibility: Int, CaseIterable, CustomStringConvertible, Equatable {
+public enum CloudAccessibility: Int, CaseIterable, CustomStringConvertible, Equatable, Sendable {
     /// Valet data can only be accessed while the device is unlocked. This attribute is recommended for data that only needs to be accessible while the application is in the foreground. Valet data with this attribute will migrate to a new device when using encrypted backups.
     case whenUnlocked = 1
     /// Valet data cannot be accessed after a restart until the device has been unlocked once; data is accessible until the device is next rebooted. This attribute is recommended for data that needs to be accessible by background applications. Valet data with this attribute will migrate to a new device when using encrypted backups.

--- a/Sources/Valet/Identifier.swift
+++ b/Sources/Valet/Identifier.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public struct Identifier: CustomStringConvertible {
+public struct Identifier: CustomStringConvertible, Sendable {
     
     // MARK: Initialization
     

--- a/Sources/Valet/Internal/Configuration.swift
+++ b/Sources/Valet/Internal/Configuration.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-internal enum Configuration: CustomStringConvertible {
+internal enum Configuration: CustomStringConvertible, Sendable {
     case valet(Accessibility)
     case iCloud(CloudAccessibility)
     case secureEnclave(SecureEnclaveAccessControl)

--- a/Sources/Valet/Internal/Service.swift
+++ b/Sources/Valet/Internal/Service.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-internal enum Service: CustomStringConvertible, Equatable {
+internal enum Service: CustomStringConvertible, Equatable, Sendable {
     case standard(Identifier, Configuration)
     case sharedGroup(SharedGroupIdentifier, Identifier?, Configuration)
 

--- a/Sources/Valet/KeychainError.swift
+++ b/Sources/Valet/KeychainError.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 @objc(VALKeychainError)
-public enum KeychainError: Int, CaseIterable, CustomStringConvertible, Error, Equatable {
+public enum KeychainError: Int, CaseIterable, CustomStringConvertible, Error, Equatable, Sendable {
     /// The keychain could not be accessed.
     case couldNotAccessKeychain
     /// User dismissed the user-presence prompt.

--- a/Sources/Valet/MigrationError.swift
+++ b/Sources/Valet/MigrationError.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 @objc(VALMigrationResult)
-public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, Equatable {
+public enum MigrationError: Int, CaseIterable, CustomStringConvertible, Error, Equatable, Sendable {
     /// Migration failed because the keychain query was not valid.
     case invalidQuery
     /// Migration failed because a key staged for migration was invalid.

--- a/Sources/Valet/SecureEnclave.swift
+++ b/Sources/Valet/SecureEnclave.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public final class SecureEnclave {
+public final class SecureEnclave: Sendable {
         
     // MARK: Internal Methods
 

--- a/Sources/Valet/SecureEnclaveAccessControl.swift
+++ b/Sources/Valet/SecureEnclaveAccessControl.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 @objc(VALSecureEnclaveAccessControl)
-public enum SecureEnclaveAccessControl: Int, CustomStringConvertible, Equatable {
+public enum SecureEnclaveAccessControl: Int, CustomStringConvertible, Equatable, Sendable {
     /// Access to keychain elements requires user presence verification via Touch ID, Face ID, or device Passcode. On macOS 10.15 and later, this element may also be accessed via a prompt on a paired watch. Keychain elements are still accessible by Touch ID even if fingers are added or removed. Touch ID does not have to be available or enrolled.
     case userPresence = 1
     

--- a/Sources/Valet/SecureEnclaveValet.swift
+++ b/Sources/Valet/SecureEnclaveValet.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. Accessing these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
 @objc(VALSecureEnclaveValet)
-public final class SecureEnclaveValet: NSObject {
+public final class SecureEnclaveValet: NSObject, Sendable {
     
     // MARK: Public Class Methods
 
@@ -92,7 +92,6 @@ public final class SecureEnclaveValet: NSObject {
         self.identifier = identifier
         self.service = service
         self.accessControl = accessControl
-        baseKeychainQuery = service.generateBaseQuery()
     }
     
     // MARK: Hashable
@@ -232,7 +231,9 @@ public final class SecureEnclaveValet: NSObject {
     // MARK: Private Properties
 
     private let lock = NSLock()
-    private let baseKeychainQuery: [String : AnyHashable]
+    private var baseKeychainQuery: [String : AnyHashable] {
+        return service.generateBaseQuery()
+    }
 
 }
 

--- a/Sources/Valet/SharedGroupIdentifier.swift
+++ b/Sources/Valet/SharedGroupIdentifier.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 
-public struct SharedGroupIdentifier: CustomStringConvertible {
+public struct SharedGroupIdentifier: CustomStringConvertible, Sendable {
 
     // MARK: Initialization
 

--- a/Sources/Valet/SinglePromptSecureEnclaveValet.swift
+++ b/Sources/Valet/SinglePromptSecureEnclaveValet.swift
@@ -25,8 +25,8 @@ import Foundation
 /// Reads and writes keychain elements that are stored on the Secure Enclave using Accessibility attribute `.whenPasscodeSetThisDeviceOnly`. The first access of these keychain elements will require the user to confirm their presence via Touch ID, Face ID, or passcode entry. If no passcode is set on the device, accessing the keychain via a `SinglePromptSecureEnclaveValet` will fail. Data is removed from the Secure Enclave when the user removes a passcode from the device.
 @objc(VALSinglePromptSecureEnclaveValet)
 @available(watchOS 3, *)
-public final class SinglePromptSecureEnclaveValet: NSObject {
-    
+public final class SinglePromptSecureEnclaveValet: NSObject, @unchecked Sendable {
+
     // MARK: Public Class Methods
 
     /// - Parameters:

--- a/Sources/Valet/Valet.swift
+++ b/Sources/Valet/Valet.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// Reads and writes keychain elements.
 @objc(VALValet)
-public final class Valet: NSObject {
+public final class Valet: NSObject, Sendable {
 
     // MARK: Public Class Methods
 
@@ -198,7 +198,6 @@ public final class Valet: NSObject {
         self.configuration = configuration
         self.service = service
         accessibility = configuration.accessibility
-        baseKeychainQuery = service.generateBaseQuery()
     }
 
     #if os(macOS)
@@ -207,7 +206,6 @@ public final class Valet: NSObject {
         self.configuration = configuration
         service = .standardOverride(service: identifier, configuration)
         accessibility = configuration.accessibility
-        baseKeychainQuery = service.generateBaseQuery()
     }
 
     private init(overrideSharedAccess identifier: SharedGroupIdentifier, configuration: Configuration) {
@@ -215,7 +213,6 @@ public final class Valet: NSObject {
         self.configuration = configuration
         service = .sharedGroupOverride(service: identifier, configuration)
         accessibility = configuration.accessibility
-        baseKeychainQuery = service.generateBaseQuery()
     }
     #endif
 
@@ -483,7 +480,9 @@ public final class Valet: NSObject {
 
     internal let configuration: Configuration
     internal let service: Service
-    internal let baseKeychainQuery: [String : AnyHashable]
+    internal var baseKeychainQuery: [String : AnyHashable] {
+        return service.generateBaseQuery()
+    }
 
     // MARK: Private Properties
 

--- a/Valet.podspec
+++ b/Valet.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'Valet'
-  s.version  = '4.2.0'
+  s.version  = '4.3.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Securely store data on iOS, tvOS, watchOS, or macOS without knowing a thing about how the Keychain works. It\'s easy. We promise.'
   s.homepage = 'https://github.com/square/Valet'
   s.authors  = 'Square'
   s.source   = { :git => 'https://github.com/square/Valet.git', :tag => s.version }
-  s.swift_version = '5.0'
+  s.swift_version = '5.4'
   s.source_files = 'Sources/Valet/**/*.{swift,h}'
   s.public_header_files = 'Sources/Valet/*.h'
   s.frameworks = 'Security'


### PR DESCRIPTION
We've been thread-safe since v1. We just hadn't told the compiler this fact yet.

This PR won't compile on Xcode 12.4 or prior, and we currently support back to Xcode 11. We therefore have two options:

1. Drop support for these long-useless Xcode builds in a feature version. This is somewhat reasonable since you haven't been able to ship to the App Store with these versions for years. We also haven't run these old versions of Xcode in CI in many years.
1. Roll a breaking change. I'd prefer to do that with more thought though: if we want a breaking change it'll be a bit before this can land + be released.

I'd be curious to hear from @pwesten and friends how they'd like to approach this before I go and update the README on this PR.