### PR TITLE
Get CI running Xcode 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,25 @@ jobs:
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
       - name: Build Framework
         run: Scripts/build.swift ${{ matrix.platforms }} spm
+  spm-14:
+    name: SPM Build macOS 14
+    runs-on: macOS-14
+    strategy:
+      matrix:
+        platforms: [
+          'iOS_17,tvOS_17,watchOS_10',
+          'macOS_14',
+        ]
+      fail-fast: false
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Bundle Install
+        run: bundle install
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer
+      - name: Prepare Simulator Runtimes
+        run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
+      - name: Build Framework
+        run: Scripts/build.swift ${{ matrix.platforms }} spm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.4
   carthage:
     name: Carthage
-    runs-on: macOS-13
+    runs-on: macOS-14
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
@@ -125,7 +125,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer
       - name: Install Carthage
         run: brew outdated carthage || brew upgrade carthage
       - name: Build Framework

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,28 @@ jobs:
       - name: Upload Coverage Reports
         if: success()
         run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
+  xcode-build-15:
+    name: Xcode 15 Build
+    runs-on: macOS-14
+    strategy:
+      matrix:
+        platforms: [
+          'iOS_17,tvOS_17,watchOS_10',
+        ]
+      fail-fast: false
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Bundle Install
+        run: bundle install
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer
+      - name: Build and Test Framework
+        run: Scripts/build.swift ${{ matrix.platforms }} xcode
+      - name: Upload Coverage Reports
+        if: success()
+        run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
   pod-lint:
     name: Pod Lint
     runs-on: macOS-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,34 +58,13 @@ jobs:
       - name: Upload Coverage Reports
         if: success()
         run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
-  xcode-build-14:
-    name: Xcode 14 Build
-    runs-on: macOS-13
-    strategy:
-      matrix:
-        platforms: [
-          'iOS_16,tvOS_16,watchOS_9',
-        ]
-      fail-fast: false
-    timeout-minutes: 30
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Bundle Install
-        run: bundle install
-      - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.app/Contents/Developer
-      - name: Build and Test Framework
-        run: Scripts/build.swift ${{ matrix.platforms }} xcode
-      - name: Upload Coverage Reports
-        if: success()
-        run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
   xcode-build-15:
     name: Xcode 15 Build
     runs-on: macOS-14
     strategy:
       matrix:
         platforms: [
+          'iOS_16,tvOS_16,watchOS_9',
           'iOS_17,tvOS_17,watchOS_10',
         ]
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -173,7 +173,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -195,7 +195,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
@@ -217,7 +217,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -52,7 +52,7 @@ enum Platform: String, CustomStringConvertible {
         case .iOS_16:
             return "platform=iOS Simulator,OS=16.4,name=iPad Pro (12.9-inch) (6th generation)"
         case .iOS_17:
-            return "platform=iOS Simulator,OS=17.0,name=iPad Pro (12.9-inch) (6th generation)"
+            return "platform=iOS Simulator,OS=17.4,name=iPad Pro (12.9-inch) (6th generation)"
 
         case .tvOS_13:
             return "platform=tvOS Simulator,OS=13.4,name=Apple TV"
@@ -63,7 +63,7 @@ enum Platform: String, CustomStringConvertible {
         case .tvOS_16:
             return "platform=tvOS Simulator,OS=16.4,name=Apple TV"
         case .tvOS_17:
-            return "platform=tvOS Simulator,OS=17.0,name=Apple TV"
+            return "platform=tvOS Simulator,OS=17.4,name=Apple TV"
 
         case .macOS_11,
              .macOS_12,
@@ -80,7 +80,7 @@ enum Platform: String, CustomStringConvertible {
         case .watchOS_9:
             return "OS=9.4,name=Apple Watch Series 6 - 44mm"
         case .watchOS_10:
-            return "OS=10.0,name=Apple Watch Series 6 - 44mm"
+            return "OS=10.4,name=Apple Watch Series 6 - 44mm"
         }
     }
 


### PR DESCRIPTION
It builds. :shipit: 

Also updated to use macOS 14 and Xcode 15 when available, and also upgraded to `checkout@v4`.

Edit: No, it doesn't build. But #313 fixes that.