### PR TITLE
Test CI weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  schedule:
+    # Runs at 00:00 UTC every Monday to ensure that CI does not bitrot.
+    - cron: '0 0 * * 1'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
@pwesten had a good idea to run CI on some regular cadence so that we can catch CI bitrot (and Github Actions deprecations) sooner rather than later. This PR creates a simple&naive implementation of this: it schedules CI to run once a week.

Ideally we'd only run this if no other CI has run that week. But that's more work – it'd likely involve hitting Github's API endpoint to determine when the last build was, which isn't super hard (ChatGPT can probably script that pretty quickly), but figured we'd start simple.

Happy to change the cadence, but I already had a repo with a weekly job so I just borrowed that code without much thought.