### PR TITLE
Get CI passing again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Build and Test Framework
         run: Scripts/build.swift ${{ matrix.platforms }} xcode
       - name: Upload Coverage Reports
@@ -48,7 +48,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=6.0 --allow-warnings # Cocoapods v1.6 now warns about potential naming colisions. We can fix this in the next breaking change.
   carthage:
@@ -61,7 +61,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Install Carthage
         run: brew outdated carthage || brew upgrade carthage
       - name: Build Framework
@@ -85,7 +85,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Build Framework
         run: Scripts/build.swift ${{ matrix.platforms }} spm
   readme-validation:

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -29,16 +29,16 @@ enum Platform: String, CustomStringConvertible {
     var destination: String {
         switch self {
         case .iOS_18:
-            "platform=iOS Simulator,OS=18.0,name=iPad (10th generation)"
+            "platform=iOS Simulator,OS=18.4,name=iPad (10th generation)"
 
         case .tvOS_18:
-            "platform=tvOS Simulator,OS=18.0,name=Apple TV"
+            "platform=tvOS Simulator,OS=18.2,name=Apple TV"
 
         case .macOS_15:
             "platform=OS X"
 
         case .watchOS_11:
-            "OS=11.0,name=Apple Watch Series 10 (46mm)"
+            "OS=11.2,name=Apple Watch Series 10 (46mm)"
         }
     }
 
@@ -51,7 +51,7 @@ enum Platform: String, CustomStringConvertible {
             "appletvsimulator"
 
         case .macOS_15:
-            "macosx15.0"
+            "macosx15.5"
 
         case .watchOS_11:
             "watchsimulator"


### PR DESCRIPTION
Github Actions has itself [an issue](https://github.com/actions/runner-images/issues/12758) running on older Xcode versions. Let's work around it by bumping CI.